### PR TITLE
Add type definitions for async variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,13 +247,13 @@ You can pass a function that returns a key, by default an identity function will
 When you iterate over the next group, the previous sub-iterator items will not be available anymore.
 ```js
 const groupBy = require('iter-tools/lib/groupby');
-groupby([1, 1, 1, 1, -1, -1, -1, 4]);
+groupBy([1, 1, 1, 1, -1, -1, -1, 4]);
 // It will return:
 // 1, subiterator (1, 1, 1, 1)
 // -1, subiterator (-1, -1, -1)
 // 4, subiterator (4)
 
-groupby([1, 1, 1, 1, 3, 3, 3, 4], (value) => {value * value});
+groupBy([11, 1, 1, 1, -1, -1, -1, 4], (value) => {value * value});
 // It will return:
 // 1, subiterator (1, 1, 1, 1, -1, -1, -1)
 // 16, subiterator (4)

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 type IterableLike<T> = Iterable<T> | T[] | { [key: string]: T; } | { [key: number]: T; };
+type AsyncIterableLike<T> = AsyncIterable<T> | IterableLike<T>;
 
 export declare function chain<T>(...iterables: IterableLike<T>[]): Iterable<T>;
 
@@ -45,10 +46,11 @@ export declare function product<T>(...iterables: IterableLike<T>[]): Iterable<[T
 
 export declare function range(opts: number | { start: number, end?: number, step?: number }): Iterable<number>;
 
-export declare function reduce<T, O>(iterable: IterableLike<T>, cb: (acc: O, item: T, c: number) => O, acc?: O): O;
-
 export declare function reduceIter<T, O>(cb: (acc: O, item: T, c: number) => O, acc?: O): (iterable: IterableLike<T>) => Iterable<O>;
 export declare function reduceIter<T, O>(cb: (acc: O, item: T, c: number) => O, acc: O, iterable: IterableLike<T>): Iterable<O>;
+
+export declare function reduce<T, O>(func: (acc: O, item: T, c: number) => O): (iterable: IterableLike<T>) => O;
+export declare function reduce<T, O>(func: (acc: O, item: T, c: number) => O, iterable: IterableLike<T>): O;
 
 export declare function regexpExec(re: RegExp): (str: string) => Iterable<string>;
 export declare function regexpExec(re: RegExp, str: string): Iterable<string>;
@@ -60,9 +62,12 @@ export declare function repeat<T>(obj: T, times?: number): Iterable<T>;
 
 export declare function slice<T>(opts: number | { start: number, end?: number, step?: number }, iterable: IterableLike<T>): Iterable<number>;
 
+export declare function takeWhile<T>(func: (item: T) => boolean): (iterable: IterableLike<T>) => Iterable<T>;
 export declare function takeWhile<T>(func: (item: T) => boolean, iterable: IterableLike<T>): Iterable<T>;
 
 export declare function tee<T>(iterable: IterableLike<T>, number?: number): Iterable<T>[];
+
+export declare function zipLongest<T>(filler: T, ...iterables: IterableLike<T>[]): Iterable<[T]>;
 
 export declare function zip<T, T2>(iterable1: IterableLike<T>[], iterable2: IterableLike<T2>[]): Iterable<[T, T2]>;
 export declare function zip<T, T2, T3>(iterable1: IterableLike<T>[], iterable2: IterableLike<T2>[], iterable3: IterableLike<T3>[]): Iterable<[T, T2, T3]>;
@@ -71,4 +76,52 @@ export declare function zip<T, T2, T3, T4, T5>(iterable1: IterableLike<T>[], ite
 export declare function zip<T, T2, T3, T4, T5, T6>(iterable1: IterableLike<T>[], iterable2: IterableLike<T2>[], iterable3: IterableLike<T3>[], iterable4: IterableLike<T4>[], iterable5: IterableLike<T5>[], iterable6: IterableLike<T6>[]): Iterable<[T, T2, T3, T4, T5, T6]>;
 export declare function zip<T>(...iterables: IterableLike<T>[]): Iterable<[T]>;
 
-export declare function zipLongest<T>(filler: T, ...iterables: IterableLike<T>[]): Iterable<[T]>;
+export declare function asyncIter<T>(syncIterable: AsyncIterableLike<T>): AsyncIterable<T>;
+
+export declare function asyncIterToArray<T>(iterable: AsyncIterableLike<T>): T[];
+
+export declare function asyncChain<T>(...iterables: AsyncIterableLike<T>[]): AsyncIterable<T>;
+
+export declare function asyncCompress<T>(iterable: AsyncIterableLike<T>, compress: AsyncIterableLike<boolean>): AsyncIterable<T>;
+
+export declare function asyncCycle<T>(iterable: AsyncIterableLike<T>): AsyncIterable<T>;
+
+export declare function asyncDropWhile<T>(func: (item: T) => boolean): (iterable: AsyncIterableLike<T>) => AsyncIterable<T>;
+export declare function asyncDropWhile<T>(func: (item: T) => boolean, iterable: AsyncIterableLike<T>): AsyncIterable<T>;
+
+export declare function asyncEnumerate<T>(iterable: AsyncIterableLike<T>, start?: number): AsyncIterable<[number, T]>;
+
+export declare function asyncExecute<T>(func: (...args: any[]) => Promise<T>, ...args: any[]): AsyncIterable<T>;
+
+export declare function asyncFilter<T>(func: (item: T) => boolean): (iterable: AsyncIterableLike<T>) => AsyncIterable<T>;
+export declare function asyncFilter<T>(func: (item: T) => boolean, iterable: AsyncIterableLike<T>): AsyncIterable<T>;
+
+export declare function asyncFlatmap<T, O>(func: (item: T) => AsyncIterableLike<O>): (iter: AsyncIterableLike<T>) => AsyncIterable<O>;
+export declare function asyncFlatmap<T, O>(func: (item: T) => AsyncIterableLike<O>, iter: AsyncIterableLike<T>): AsyncIterable<O>;
+
+export declare function asyncGroupBy<T, K>(iterable: AsyncIterableLike<T>, key?: (item: T) => K): AsyncIterable<[K, AsyncIterable<T>]>;
+
+export declare function asyncMap<T, O>(func: (item: T) => O): (iter: AsyncIterableLike<T>) => AsyncIterable<O>;
+export declare function asyncMap<T, O>(func: (item: T) => O, iter: AsyncIterableLike<T>): AsyncIterable<O>;
+
+export declare function asyncReduceIter<T, O>(cb: (acc: O, item: T, c: number) => O, acc?: O): (iterable: AsyncIterableLike<T>) => AsyncIterable<O>;
+export declare function asyncReduceIter<T, O>(cb: (acc: O, item: T, c: number) => O, acc: O, iterable: AsyncIterableLike<T>): AsyncIterable<O>;
+
+export declare function asyncReduce<T, O>(func: (acc: O, item: T, c: number) => O): (iterable: AsyncIterableLike<T>) => O;
+export declare function asyncReduce<T, O>(func: (acc: O, item: T, c: number) => O, iterable: AsyncIterableLike<T>): O;
+
+export declare function asyncSlice<T>(opts: number | { start: number, end?: number, step?: number }, iterable: AsyncIterableLike<T>): AsyncIterable<number>;
+
+export declare function asyncTakeWhile<T>(func: (item: T) => boolean): (iterable: AsyncIterableLike<T>) => AsyncIterable<T>;
+export declare function asyncTakeWhile<T>(func: (item: T) => boolean, iterable: AsyncIterableLike<T>): AsyncIterable<T>;
+
+export declare function asyncTee<T>(iterable: AsyncIterableLike<T>, number?: number): AsyncIterable<T>[];
+
+export declare function asyncZipLongest<T>(filler: T, ...iterables: AsyncIterableLike<T>[]): AsyncIterable<[T]>;
+
+export declare function asyncZip<T, T2>(iterable1: AsyncIterableLike<T>[], iterable2: AsyncIterableLike<T2>[]): AsyncIterable<[T, T2]>;
+export declare function asyncZip<T, T2, T3>(iterable1: AsyncIterableLike<T>[], iterable2: AsyncIterableLike<T2>[], iterable3: AsyncIterableLike<T3>[]): AsyncIterable<[T, T2, T3]>;
+export declare function asyncZip<T, T2, T3, T4>(iterable1: AsyncIterableLike<T>[], iterable2: AsyncIterableLike<T2>[], iterable3: AsyncIterableLike<T3>[], iterable4: AsyncIterableLike<T4>[]): AsyncIterable<[T, T2, T3, T4]>;
+export declare function asyncZip<T, T2, T3, T4, T5>(iterable1: AsyncIterableLike<T>[], iterable2: AsyncIterableLike<T2>[], iterable3: AsyncIterableLike<T3>[], iterable4: AsyncIterableLike<T4>[], iterable5: AsyncIterableLike<T5>[]): AsyncIterable<[T, T2, T3, T4, T5]>;
+export declare function asyncZip<T, T2, T3, T4, T5, T6>(iterable1: AsyncIterableLike<T>[], iterable2: AsyncIterableLike<T2>[], iterable3: AsyncIterableLike<T3>[], iterable4: AsyncIterableLike<T4>[], iterable5: AsyncIterableLike<T5>[], iterable6: AsyncIterableLike<T6>[]): AsyncIterable<[T, T2, T3, T4, T5, T6]>;
+export declare function asyncZip<T>(...iterables: AsyncIterableLike<T>[]): AsyncIterable<[T]>;

--- a/lib/async/async-iter-to-array.d.ts
+++ b/lib/async/async-iter-to-array.d.ts
@@ -1,0 +1,2 @@
+import { asyncIterToArray } from '../../index';
+export = asyncIterToArray;

--- a/lib/async/async-iter.d.ts
+++ b/lib/async/async-iter.d.ts
@@ -1,0 +1,2 @@
+import { asyncIter } from '../../index';
+export = asyncIter;

--- a/lib/async/chain.d.ts
+++ b/lib/async/chain.d.ts
@@ -1,0 +1,2 @@
+import { asyncChain } from '../../index';
+export = asyncChain;

--- a/lib/async/compress.d.ts
+++ b/lib/async/compress.d.ts
@@ -1,0 +1,2 @@
+import { asyncCompress } from '../../index';
+export = asyncCompress;

--- a/lib/async/cycle.d.ts
+++ b/lib/async/cycle.d.ts
@@ -1,0 +1,2 @@
+import { asyncCycle } from '../../index';
+export = asyncCycle;

--- a/lib/async/drop-while.d.ts
+++ b/lib/async/drop-while.d.ts
@@ -1,0 +1,2 @@
+import { asyncDropWhile } from '../../index';
+export = asyncDropWhile;

--- a/lib/async/enumerate.d.ts
+++ b/lib/async/enumerate.d.ts
@@ -1,0 +1,2 @@
+import { asyncEnumerate } from '../../index';
+export = asyncEnumerate;

--- a/lib/async/execute.d.ts
+++ b/lib/async/execute.d.ts
@@ -1,0 +1,2 @@
+import { asyncExecute } from '../../index';
+export = asyncExecute;

--- a/lib/async/filter.d.ts
+++ b/lib/async/filter.d.ts
@@ -1,0 +1,2 @@
+import { asyncFilter } from '../../index';
+export = asyncFilter;

--- a/lib/async/flat-map.d.ts
+++ b/lib/async/flat-map.d.ts
@@ -1,0 +1,2 @@
+import { asyncFlatmap } from '../../index';
+export = asyncFlatmap;

--- a/lib/async/groupby.d.ts
+++ b/lib/async/groupby.d.ts
@@ -1,0 +1,2 @@
+import { asyncGroupBy } from '../../index';
+export = asyncGroupBy;

--- a/lib/async/map.d.ts
+++ b/lib/async/map.d.ts
@@ -1,0 +1,2 @@
+import { asyncMap } from '../../index';
+export = asyncMap;

--- a/lib/async/reduce-iter.d.ts
+++ b/lib/async/reduce-iter.d.ts
@@ -1,0 +1,2 @@
+import { asyncReduceIter } from '../../index';
+export = asyncReduceIter;

--- a/lib/async/reduce.d.ts
+++ b/lib/async/reduce.d.ts
@@ -1,0 +1,2 @@
+import { asyncReduce } from '../../index';
+export = asyncReduce;

--- a/lib/async/slice.d.ts
+++ b/lib/async/slice.d.ts
@@ -1,0 +1,2 @@
+import { asyncSlice } from '../../index';
+export = asyncSlice;

--- a/lib/async/take-while.d.ts
+++ b/lib/async/take-while.d.ts
@@ -1,0 +1,2 @@
+import { asyncTakeWhile } from '../../index';
+export = asyncTakeWhile;

--- a/lib/async/tee.d.ts
+++ b/lib/async/tee.d.ts
@@ -1,0 +1,2 @@
+import { asyncTee } from '../../index';
+export = asyncTee;

--- a/lib/async/zip-longest.d.ts
+++ b/lib/async/zip-longest.d.ts
@@ -1,0 +1,2 @@
+import { asyncZipLongest } from '../../index';
+export = asyncZipLongest;

--- a/lib/async/zip.d.ts
+++ b/lib/async/zip.d.ts
@@ -1,0 +1,2 @@
+import { asyncZip } from '../../index';
+export = asyncZip;


### PR DESCRIPTION
Add `.d.ts` files in response to #4. 

Requires `--lib ESNext.AsyncIterable` argument to be used on TypeScript compiler.