### PR TITLE
Proposed changes to slice support for negative indicies

### DIFF
--- a/src/async-slice.mjs
+++ b/src/async-slice.mjs
@@ -18,7 +18,7 @@ async function * simpleSlice (iterable, start, end, step) {
       if (buffer.length > bufferSize) {
         item = buffer.shift()
       } else {
-        continue;
+        continue
       }
     }
 
@@ -43,14 +43,14 @@ async function * slice (opts, iterable) {
   start = opts.start ? opts.start : 0
   iterable = ensureAsyncIterable(iterable)
 
-  if (step === 0) {
-    throw new TypeError("Cannot slice with step = 0")
+  if (step <= 0) {
+    throw new TypeError('Cannot slice with step <= 0')
   }
 
   if (start >= 0) {
     yield * simpleSlice(iterable, start, end, step)
   } else {
-    const array = await asyncToArray(iterable);
+    const array = await asyncToArray(iterable)
     start = start < 0 ? array.length + start : start
     end = end < 0 && isFinite(end) ? array.length + end : end
 

--- a/src/internal/ensure-iterable.mjs
+++ b/src/internal/ensure-iterable.mjs
@@ -4,9 +4,9 @@ export default function ensureIterable (i) {
     return emptyArr[Symbol.iterator]()
   } else if (!i[Symbol.iterator]) {
     if (typeof i.next === 'function') {
-      throw new Error('Iterators are not supported arguments to iter-tools. You must wrap them using the `iterable` method.')
+      throw new TypeError('Iterators are not supported arguments to iter-tools. You must wrap them using the `iterable` method.')
     }
-    throw new Error('The argument is not an iterable, or null')
+    throw new TypeError('The argument is not an iterable or null')
   }
   return i
 }

--- a/src/slice.mjs
+++ b/src/slice.mjs
@@ -1,10 +1,36 @@
-import ensureIterable from './internal/ensure-iterable'
 import Dequeue from 'dequeue'
+import ensureIterable from './internal/ensure-iterable'
+import toArray from './to-array'
 
-function * deQueueIter (dequeue) {
-  const len = dequeue.length
-  for (let i = 0; i < len; i++) {
-    yield dequeue.shift()
+function * simpleSlice (iterable, start, end, step) {
+  let currentPos = 0
+  let nextValidPos = start
+  let bufferSize = Math.abs(end)
+  let buffer
+
+  if (end < 0) {
+    buffer = new Dequeue()
+  }
+
+  for (let item of iterable) {
+    if (buffer) {
+      buffer.push(item)
+      if (buffer.length > bufferSize) {
+        item = buffer.shift()
+      } else {
+        continue;
+      }
+    }
+
+    if (currentPos >= end && end >= 0) {
+      break
+    }
+
+    if (nextValidPos === currentPos) {
+      yield item
+      nextValidPos += step
+    }
+    currentPos++
   }
 }
 
@@ -17,61 +43,18 @@ function * slice (opts, iterable) {
   start = opts.start ? opts.start : 0
   iterable = ensureIterable(iterable)
 
-  if (start >= 0 && end >= 0) {
-    let currentPos = 0
-    let nextValidPos = start
+  if (step === 0) {
+    throw new TypeError("Cannot slice with step = 0")
+  }
 
-    for (const item of iterable) {
-      if (currentPos >= end) {
-        break
-      }
+  if (start >= 0) {
+    yield * simpleSlice(iterable, start, end, step)
+  } else {
+    const array = toArray(iterable);
+    start = start < 0 ? array.length + start : start
+    end = end < 0 && isFinite(end) ? array.length + end : end
 
-      if (nextValidPos === currentPos) {
-        yield item
-        nextValidPos += step
-      }
-      currentPos++
-    }
-  } else if (start >= 0 && end < 0) {
-    let buffer = []
-    let currentPos = 0
-
-    for (const item of iterable) {
-      if (currentPos >= start) {
-        buffer.push(item)
-      }
-      currentPos++
-    }
-    buffer = buffer.slice(0, end)
-    yield * slice({ step }, buffer)
-  } else if (start < 0 && end >= 0) {
-    // buffer from 0 to end. Finish iteration after end + abs(start)
-    let buffer = []
-    let currentPos = 0
-
-    for (const item of iterable) {
-      if (currentPos >= end) {
-        break
-      }
-      buffer.push(item)
-      currentPos++
-    }
-    buffer = buffer.slice(start)
-    yield * slice({ step }, buffer)
-  } else { // (start < 0 && end < 0)
-    if (start >= end) {
-      return
-    }
-    const queue = new Dequeue()
-    const queueMaxSize = Math.abs(start - end) + Math.abs(end)
-
-    for (const item of iterable) {
-      queue.push(item)
-      if (queue.length > queueMaxSize) {
-        queue.shift()
-      }
-    }
-    yield * slice({start: 0, end: queue.length + end, step}, deQueueIter(queue))
+    yield * simpleSlice(array, start, end, step)
   }
 }
 

--- a/src/slice.mjs
+++ b/src/slice.mjs
@@ -18,7 +18,7 @@ function * simpleSlice (iterable, start, end, step) {
       if (buffer.length > bufferSize) {
         item = buffer.shift()
       } else {
-        continue;
+        continue
       }
     }
 
@@ -43,14 +43,14 @@ function * slice (opts, iterable) {
   start = opts.start ? opts.start : 0
   iterable = ensureIterable(iterable)
 
-  if (step === 0) {
-    throw new TypeError("Cannot slice with step = 0")
+  if (step <= 0) {
+    throw new TypeError('Cannot slice with step <= 0')
   }
 
   if (start >= 0) {
     yield * simpleSlice(iterable, start, end, step)
   } else {
-    const array = toArray(iterable);
+    const array = toArray(iterable)
     start = start < 0 ? array.length + start : start
     end = end < 0 && isFinite(end) ? array.length + end : end
 


### PR DESCRIPTION
I needed to fiddle with the code to compose my thoughts on this. I think the advantages are:
- it doesn't look infinitely recursive
- there's only one for loop
- should be fast in the expected case (trimming one or two items off the end) because the buffer will never get larger than one or two items
- items that fall out of the buffer are yielded immediately, which is very important for async iterables

TODOS: use a circular array as the buffer -- should perform even better than linked list.

