### PR TITLE
Fix https://github.com/sithmel/iter-tools/issues/57

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7392,9 +7392,9 @@
       "dev": true
     },
     "typescript-tuple": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/typescript-tuple/-/typescript-tuple-1.2.1.tgz",
-      "integrity": "sha512-qdTRLaMjT+WsDpk37R5f9nZ4pAFZvi07eLwWtViJtj/zdLqHXLl/1x0lYyUhcruhtcU+3o+JixD5gq/ix1F6dA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/typescript-tuple/-/typescript-tuple-1.4.0.tgz",
+      "integrity": "sha512-z1Mvrdo8ZQC0JD65KgwUk7BYO84NsvHoTupyqvZ+4PTMzVBq9VR0C40+m65gKZPTuoSj7gKXQVXiU0hmEt0/MA=="
     },
     "uglify-js": {
       "version": "2.8.29",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2879,8 +2879,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2901,14 +2900,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2923,20 +2920,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3053,8 +3047,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3066,7 +3059,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3081,7 +3073,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3089,14 +3080,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3115,7 +3104,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3196,8 +3184,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3209,7 +3196,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3295,8 +3281,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3332,7 +3317,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3352,7 +3336,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3396,14 +3379,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "clone-regexp": "^2.0.1",
     "dequeue": "^1.0.5",
     "little-ds-toolkit": "^1.1.0",
-    "typescript-tuple": "1.2.1"
+    "typescript-tuple": "^1.4.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "jsnext:main": "es5/index.mjs",
   "typings": "es5/index.d.ts",
   "scripts": {
-    "lint": "eslint --fix --ext .mjs,.js ./src ./src/__test__ ./benchmarks",
+    "lint": "eslint --fix --ext .mjs,.js ./src ./src/__test__ ./benchmarks && npm run tslint",
     "test:es5": "npm run build:es5-cjs && jest --moduleNameMapper '{\"^iter-tools(.*)\": \"<rootDir>/es5$1\"}'",
     "test:es2015": "npm run build:es2015-cjs && jest --moduleNameMapper '{\"^iter-tools(.*)\": \"<rootDir>/es2015$1\"}'",
     "test:es2018": "npm run build:es2018-cjs && jest --moduleNameMapper '{\"^iter-tools(.*)\": \"<rootDir>/es2018$1\"}'",
@@ -17,7 +17,7 @@
     "coverage:badges": "jest-coverage-badges",
     "coverage": "npm run test:es2015 -- --coverage --coverageDirectory=coverage --config '{ \"coverageReporters\" : [\"lcov\", \"json-summary\"]}' && npm run coverage:badges",
     "clean": "rimraf es5 es2015 es2018",
-    "build": "npm run clean && npm run build:es5 && npm run build:es5-cjs && npm run build:es2015 && npm run build:es2015-cjs && npm run build:es2018 && npm run build:es2018-cjs && npm run build:copyts",
+    "build": "npm run clean && npm run lint && npm run build:es5 && npm run build:es5-cjs && npm run build:es2015 && npm run build:es2015-cjs && npm run build:es2018 && npm run build:es2018-cjs && npm run build:copyts",
     "build:es5": "cross-env BABEL_ENV=es5 babel --keep-file-extension -x \".mjs\" src -d es5",
     "build:es5-cjs": "cross-env BABEL_ENV=es5-cjs babel -x \".mjs\" src -d es5",
     "build:es2015": "cross-env BABEL_ENV=es2015 babel --keep-file-extension -x \".mjs\" src -d es2015",
@@ -26,6 +26,7 @@
     "build:es2018-cjs": "cross-env BABEL_ENV=es2018-cjs babel -x \".mjs\" src -d es2018",
     "build:copyts": "copyfiles -f src/*.ts es5 && copyfiles -f src/*.ts es2015 && copyfiles -f src/*.ts es2018",
     "tslint": "tslint -c tslint.json 'src/**/*.ts'",
+    "tslint:fix": "npm run tslint -- --fix",
     "prepublish": "npm run build",
     "precommit": "npm run lint",
     "prepush": "npm run test"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,7 @@
 /// <reference lib="es2018" />
 /// <reference lib="esnext.asynciterable" />
 
-import { Repeat, Prepend, Reverse } from 'typescript-tuple'
+import { Prepend, Repeat, Reverse } from "typescript-tuple";
 
 type IterableLike<T> = Iterable<T> | T[] | { [key: string]: T; } | { [key: number]: T; };
 type AsyncIterableLike<T> = AsyncIterable<T> | IterableLike<T>;
@@ -18,12 +18,12 @@ type ProductReturn<Args extends any[][], Holder extends any[][] = []> = {
   many: ((...a: Reverse<Args>) => any) extends ((a: infer Last, ...b: infer ReversedRest) => any)
     ? ProductReturn<
       Reverse<ReversedRest>,
-      Prepend<Holder, Last extends (infer T)[] ? T : never>
+      Prepend<Holder, Last extends Array<infer T> ? T : never>
     >
-    : never
+    : never,
 }[
-  Args extends [] ? 'empty' : 'many'
-]
+  Args extends [] ? "empty" : "many"
+];
 
 // Sync
 export declare function keys(iterable: any): Iterable<any>;
@@ -38,7 +38,10 @@ export declare function concat<T>(...iterables: Array<IterableLike<T>>): Iterabl
 
 export declare function combinations<T, R extends number>(iterable: IterableLike<T>, r: R): Iterable<Repeat<T, R>>;
 
-export declare function combinationsWithReplacement<T, R extends number>(iterable: IterableLike<T>, r: R): Iterable<Repeat<T, R>>;
+export declare function combinationsWithReplacement<T, R extends number>(
+  iterable: IterableLike<T>,
+  r: R,
+): Iterable<Repeat<T, R>>;
 
 export declare function compose<T>(fns: IterableLike<(_: T) => T>): Iterable<T>;
 
@@ -83,7 +86,7 @@ export declare function map<T, O>(func: (item: T) => O, iter: IterableLike<T>): 
 export declare function permutations<T, R extends number>(iterable: IterableLike<T>, r: R): Iterable<Repeat<T, R>>;
 
 export declare function product<T>(...iterables: Array<IterableLike<T>>): Iterable<T[]>;
-export declare function product<Args extends any[][]>(...iterables: Args): Iterable<ProductReturn<Args>>
+export declare function product<Args extends any[][]>(...iterables: Args): Iterable<ProductReturn<Args>>;
 export declare function range(opts: number | { start: number, end?: number, step?: number }): Iterable<number>;
 
 export declare function reduce<T, O>(func: (acc: O, item: T, c: number) => O): (iterable: IterableLike<T>) => O;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -13,7 +13,7 @@ type AsyncIterableLike<T> = AsyncIterable<T> | IterableLike<T>;
  * @example
  *   `ProductReturn<[string[], number[], boolean[]]>` is `[string, number, boolean]`
  */
-type ProductReturn<Args extends any[][], Holder extends any[][] = []> = {
+type ProductReturn<Args extends any[][], Holder extends any[] = []> = {
   empty: Holder,
   many: ((...a: Reverse<Args>) => any) extends ((a: infer Last, ...b: infer ReversedRest) => any)
     ? ProductReturn<


### PR DESCRIPTION
## Changes

* Upgrade dependency `typescript-tuple` to `^1.4.0`

## Details

> #### When `r > iterables.length`
>
> Type defintion is correct when `r <= iterables.length`, but when it isn't, the function returns `[]` but TypeScript still sees it as `Repeat<T, R>` (tuples of `r` length).

As it turns out, `[]` is compatible with any array type, including `Repeat<T, R>`, so there's already no needs to fix this. Silly me!


> #### When `r`'s exact value is not known
>
> Type definition is correct when `r` is a known constant (such as `2`, `3`, `4`), but if it is something more ambiguous (such as `number`, `2 | 3`), results' length is set to smallest number of set (i.e. `0` for `number`, `2` for `2 | 3`).

This is fixed due to `Repeat` being fixed in `typescript-tuple`.