### PR TITLE
Test TypeScript definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@
 
 /coverage/*
 !/coverage/badge-*.svg
-__spec__/*.js
-__spec__/*.d.ts
+/src/__spec__/*.js
+/src/__spec__/*.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 
 /coverage/*
 !/coverage/badge-*.svg
+__spec__/*.js
+__spec__/*.d.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -7026,6 +7026,15 @@
         }
       }
     },
+    "static-type-assert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/static-type-assert/-/static-type-assert-2.0.0.tgz",
+      "integrity": "sha512-uILFDti9+qLpmZyfqSNSmySwI1B6Q3CxRWhijWtDNs78GCqrLjVxuN0GXeAsKFolOxuAGEtP/QOftR44+vLehA==",
+      "dev": true,
+      "requires": {
+        "typescript-compare": "^0.0.0"
+      }
+    },
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
@@ -7386,9 +7395,24 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
-      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
+      "integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
+      "dev": true
+    },
+    "typescript-compare": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-compare/-/typescript-compare-0.0.0.tgz",
+      "integrity": "sha512-WuGIIbeH6s6i06WaExp0hrtiHC6L34+HDGQdm8HnKhEuOws36TXubri7L6nOQz1GFaRfR2xY94L+bojDnkEaww==",
+      "dev": true,
+      "requires": {
+        "typescript-logic": "^0.0.0"
+      }
+    },
+    "typescript-logic": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-logic/-/typescript-logic-0.0.0.tgz",
+      "integrity": "sha512-zXFars5LUkI3zP492ls0VskH3TtdeHCqu0i7/duGt60i5IGPIpAHE/DWo5FqJ6EjQ15YKXrt+AETjv60Dat34Q==",
       "dev": true
     },
     "typescript-tuple": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test:es5": "npm run build:es5-cjs && jest --moduleNameMapper '{\"^iter-tools(.*)\": \"<rootDir>/es5$1\"}'",
     "test:es2015": "npm run build:es2015-cjs && jest --moduleNameMapper '{\"^iter-tools(.*)\": \"<rootDir>/es2015$1\"}'",
     "test:es2018": "npm run build:es2018-cjs && jest --moduleNameMapper '{\"^iter-tools(.*)\": \"<rootDir>/es2018$1\"}'",
-    "test": "npm run test:es5 && npm run test:es2015",
+    "test:types": "tsc",
+    "test": "npm run test:es5 && npm run test:es2015 && npm run test:types",
     "watch": "jest --moduleNameMapper '{\"^iter-tools(.*)\": \"<rootDir>/es2015$1\"}' --watch",
     "benchmarks": "npm run clean && npm run build:es2018-cjs && node --expose-gc benchmarks",
     "coverage:badges": "jest-coverage-badges",
@@ -82,7 +83,8 @@
     "require-all": "^2.2.0",
     "rimraf": "^2.6.2",
     "tslint": "^5.11.0",
-    "typescript": "^3.0.1"
+    "static-type-assert": "^2.0.0",
+    "typescript": "^3.0.3"
   },
   "jest": {
     "testEnvironment": "node",

--- a/src/__spec__/types.spec.ts
+++ b/src/__spec__/types.spec.ts
@@ -3,11 +3,14 @@ import * as tuple from "typescript-tuple";
 import * as iter from "../index";
 import compare = assert.compare;
 
-const a = iter.combinations([0, 1, 2, 3], 3);
-compare<typeof a, Iterable<[number, number, number]>>("equal");
+assert<
+  Iterable<[number, number, number]>
+>(iter.combinations([0, 1, 2, 3], 3));
 
-const b = iter.permutations([0, 1, 2, 3], 3);
-compare<typeof b, Iterable<[number, number, number]>>("equal");
+assert<
+  Iterable<[number, number, number]>
+>(iter.permutations([0, 1, 2, 3], 3));
 
-const c = iter.product([0, 1, 2], [3, 4, 5]);
-compare<typeof c, Iterable<number[]>>("equal");
+assert<
+  Iterable<number[]>
+>(iter.product([0, 1, 2], [3, 4, 5]));

--- a/src/__spec__/types.spec.ts
+++ b/src/__spec__/types.spec.ts
@@ -1,7 +1,5 @@
 import assert from "static-type-assert";
-import * as tuple from "typescript-tuple";
 import * as iter from "../index";
-import compare = assert.compare;
 
 assert<
   Iterable<[number, number, number]>

--- a/src/__spec__/types.spec.ts
+++ b/src/__spec__/types.spec.ts
@@ -1,0 +1,13 @@
+import assert from "static-type-assert";
+import * as tuple from "typescript-tuple";
+import * as iter from "../index";
+import compare = assert.compare;
+
+const a = iter.combinations([0, 1, 2, 3], 3);
+compare<typeof a, Iterable<[number, number, number]>>("equal");
+
+const b = iter.permutations([0, 1, 2, 3], 3);
+compare<typeof b, Iterable<[number, number, number]>>("equal");
+
+const c = iter.product([0, 1, 2], [3, 4, 5]);
+compare<typeof c, Iterable<number[]>>("equal");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "commonjs",
+    "lib": ["es2017", "es2018", "esnext"],
+    "noEmit": true,
+    "declaration": false,
+    "strict": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "pretty": true
+  },
+  "include": [
+    "src/__spec__"
+  ]
+}


### PR DESCRIPTION
This pull request provides a way to test `src/index.d.ts`.

### Why?

Prior to https://github.com/sithmel/iter-tools/pull/55, I find TypeScript definitions of this library is very inaccurate, so I feel the need to fix it. I also want to take advantage of TS 3.0 to improve the types, but I did it bindly, hoping it would work. Now with this change, everyone can add tests to verify if TS definition is correct.

### Changes

* Install [`static-type-assert`](https://github.com/ksxnodemodules/static-type-assert) (author: me) as a dev dependency
* Update `typescript` dependency to `3.0.3`
* Create script `"test:types"` and add it to `"test"`

### How would it works?

1. Tester writes type assertion statements into `src/__spec__/types.spec.ts`.
2. Run `tsc`.
