### PR TITLE
[TypeScript] Impose limit on parameter r of permutations/combinations functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@
 
 /coverage/*
 !/coverage/badge-*.svg
-__spec__/*.js
-__spec__/*.d.ts
+/src/__spec__/*.js
+/src/__spec__/*.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 
 /coverage/*
 !/coverage/badge-*.svg
+__spec__/*.js
+__spec__/*.d.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -7026,6 +7026,15 @@
         }
       }
     },
+    "static-type-assert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/static-type-assert/-/static-type-assert-2.0.0.tgz",
+      "integrity": "sha512-uILFDti9+qLpmZyfqSNSmySwI1B6Q3CxRWhijWtDNs78GCqrLjVxuN0GXeAsKFolOxuAGEtP/QOftR44+vLehA==",
+      "dev": true,
+      "requires": {
+        "typescript-compare": "^0.0.0"
+      }
+    },
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
@@ -7386,9 +7395,24 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
-      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
+      "integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
+      "dev": true
+    },
+    "typescript-compare": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-compare/-/typescript-compare-0.0.0.tgz",
+      "integrity": "sha512-WuGIIbeH6s6i06WaExp0hrtiHC6L34+HDGQdm8HnKhEuOws36TXubri7L6nOQz1GFaRfR2xY94L+bojDnkEaww==",
+      "dev": true,
+      "requires": {
+        "typescript-logic": "^0.0.0"
+      }
+    },
+    "typescript-logic": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-logic/-/typescript-logic-0.0.0.tgz",
+      "integrity": "sha512-zXFars5LUkI3zP492ls0VskH3TtdeHCqu0i7/duGt60i5IGPIpAHE/DWo5FqJ6EjQ15YKXrt+AETjv60Dat34Q==",
       "dev": true
     },
     "typescript-tuple": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7420,6 +7420,22 @@
       "resolved": "https://registry.npmjs.org/typescript-tuple/-/typescript-tuple-1.4.0.tgz",
       "integrity": "sha512-z1Mvrdo8ZQC0JD65KgwUk7BYO84NsvHoTupyqvZ+4PTMzVBq9VR0C40+m65gKZPTuoSj7gKXQVXiU0hmEt0/MA=="
     },
+    "typescript-union": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-union/-/typescript-union-0.0.0.tgz",
+      "integrity": "sha512-sWOTNcTOXw27cJhfvjSbxrKggb4XD+fPIFkjIqqnycdVqStj/3IR3QVEMZOheWY5ELGS3PCwuHFDVWAbK9UHvA==",
+      "requires": {
+        "typescript-tuple": "^1.5.0",
+        "utility-types": "^2.0.0"
+      },
+      "dependencies": {
+        "typescript-tuple": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/typescript-tuple/-/typescript-tuple-1.5.0.tgz",
+          "integrity": "sha512-yxjhz3QFPq3wLBMMKGvKagfvCsxY5qUGBFOVtCvdXNKFdWvQbkVdBvI2CtTACubJddZHPzBaa2zvmkm9TBt2TA=="
+        }
+      }
+    },
     "uglify-js": {
       "version": "2.8.29",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
@@ -7617,6 +7633,11 @@
         "define-properties": "^1.1.2",
         "object.getownpropertydescriptors": "^2.0.3"
       }
+    },
+    "utility-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-2.1.0.tgz",
+      "integrity": "sha512-/nP2gqavggo6l38rtQI/CdeV+2fmBGXVvHgj9kV2MAnms3TIi77Mz9BtapPFI0+GZQCqqom0vACQ+VlTTaCovw=="
     },
     "uuid": {
       "version": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "clone-regexp": "^2.0.1",
     "dequeue": "^1.0.5",
     "little-ds-toolkit": "^1.1.0",
-    "typescript-tuple": "^1.4.0"
+    "typescript-tuple": "^1.4.0",
+    "typescript-union": "0.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test:es5": "npm run build:es5-cjs && jest --moduleNameMapper '{\"^iter-tools(.*)\": \"<rootDir>/es5$1\"}'",
     "test:es2015": "npm run build:es2015-cjs && jest --moduleNameMapper '{\"^iter-tools(.*)\": \"<rootDir>/es2015$1\"}'",
     "test:es2018": "npm run build:es2018-cjs && jest --moduleNameMapper '{\"^iter-tools(.*)\": \"<rootDir>/es2018$1\"}'",
-    "test": "npm run test:es5 && npm run test:es2015",
+    "test:types": "tsc",
+    "test": "npm run test:es5 && npm run test:es2015 && npm run test:types",
     "watch": "jest --moduleNameMapper '{\"^iter-tools(.*)\": \"<rootDir>/es2015$1\"}' --watch",
     "benchmarks": "npm run clean && npm run build:es2018-cjs && node --expose-gc benchmarks",
     "coverage:badges": "jest-coverage-badges",
@@ -82,7 +83,8 @@
     "require-all": "^2.2.0",
     "rimraf": "^2.6.2",
     "tslint": "^5.11.0",
-    "typescript": "^3.0.1"
+    "static-type-assert": "^2.0.0",
+    "typescript": "^3.0.3"
   },
   "jest": {
     "testEnvironment": "node",

--- a/src/__spec__/types.spec.ts
+++ b/src/__spec__/types.spec.ts
@@ -6,8 +6,14 @@ import compare = assert.compare;
 const a = iter.combinations([0, 1, 2, 3], 3);
 compare<typeof a, Iterable<[number, number, number]>>("equal");
 
+const a0 = iter.combinations([0, 1, 2, 3], Number());
+compare<typeof a0, Iterable<number[]>>("equal");
+
 const b = iter.permutations([0, 1, 2, 3], 3);
 compare<typeof b, Iterable<[number, number, number]>>("equal");
+
+const b0 = iter.permutations([0, 1, 2, 3], Number());
+compare<typeof b0, Iterable<number[]>>("equal");
 
 const c = iter.product([0, 1, 2], [3, 4, 5]);
 compare<typeof c, Iterable<number[]>>("equal");

--- a/src/__spec__/types.spec.ts
+++ b/src/__spec__/types.spec.ts
@@ -1,5 +1,4 @@
 import assert from "static-type-assert";
-import * as tuple from "typescript-tuple";
 import * as iter from "../index";
 import compare = assert.compare;
 

--- a/src/__spec__/types.spec.ts
+++ b/src/__spec__/types.spec.ts
@@ -9,11 +9,17 @@ compare<typeof a, Iterable<[number, number, number]>>("equal");
 const a0 = iter.combinations([0, 1, 2, 3], Number());
 compare<typeof a0, Iterable<number[]>>("equal");
 
+const a1 = iter.combinations([0, 1, 2, 3], 999);
+compare<typeof a1, Iterable<number[]>>("equal");
+
 const b = iter.permutations([0, 1, 2, 3], 3);
 compare<typeof b, Iterable<[number, number, number]>>("equal");
 
 const b0 = iter.permutations([0, 1, 2, 3], Number());
 compare<typeof b0, Iterable<number[]>>("equal");
+
+const b1 = iter.permutations([0, 1, 2, 3], 999);
+compare<typeof b1, Iterable<number[]>>("equal");
 
 const c = iter.product([0, 1, 2], [3, 4, 5]);
 compare<typeof c, Iterable<number[]>>("equal");

--- a/src/__spec__/types.spec.ts
+++ b/src/__spec__/types.spec.ts
@@ -1,0 +1,13 @@
+import assert from "static-type-assert";
+import * as tuple from "typescript-tuple";
+import * as iter from "../index";
+import compare = assert.compare;
+
+const a = iter.combinations([0, 1, 2, 3], 3);
+compare<typeof a, Iterable<[number, number, number]>>("equal");
+
+const b = iter.permutations([0, 1, 2, 3], 3);
+compare<typeof b, Iterable<[number, number, number]>>("equal");
+
+const c = iter.product([0, 1, 2], [3, 4, 5]);
+compare<typeof c, Iterable<number[]>>("equal");

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -12,7 +12,7 @@ type ReasonableNumber = UnionRange<32>;
  * Function signature of `permutations` and `combinations`
  */
 type CombinationsPermutations = <T, R extends number>(iterable: IterableLike<T>, r: R) =>
-  Iterable<R extends ReasonableNumber ? Repeat<T, R> : number[]>;
+  Iterable<R extends ReasonableNumber ? Repeat<T, R> : T[]>;
 
 /**
  * Helper generic for `product` function

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,9 +2,17 @@
 /// <reference lib="esnext.asynciterable" />
 
 import { Prepend, Repeat, Reverse } from "typescript-tuple";
+import { RangeZero as UnionRange } from "typescript-union";
 
 type IterableLike<T> = Iterable<T> | T[] | { [key: string]: T; } | { [key: number]: T; };
 type AsyncIterableLike<T> = AsyncIterable<T> | IterableLike<T>;
+type ReasonableNumber = UnionRange<32>;
+
+/**
+ * Function signature of `permutations` and `combinations`
+ */
+type CombinationsPermutations = <T, R extends number>(iterable: IterableLike<T>, r: R) =>
+  Iterable<R extends ReasonableNumber ? Repeat<T, R> : number[]>;
 
 /**
  * Helper generic for `product` function
@@ -36,12 +44,8 @@ export declare function batch<T>(n: number, iterable: IterableLike<T>): Iterable
 export declare function chain<T>(...iterables: Array<IterableLike<T>>): Iterable<T>;
 export declare function concat<T>(...iterables: Array<IterableLike<T>>): Iterable<T>;
 
-export declare function combinations<T, R extends number>(iterable: IterableLike<T>, r: R): Iterable<Repeat<T, R>>;
-
-export declare function combinationsWithReplacement<T, R extends number>(
-  iterable: IterableLike<T>,
-  r: R,
-): Iterable<Repeat<T, R>>;
+export declare const combinations: CombinationsPermutations;
+export declare const combinationsWithReplacement: CombinationsPermutations;
 
 export declare function compose<T>(fns: IterableLike<(_: T) => T>): Iterable<T>;
 
@@ -83,7 +87,7 @@ export declare function iterable<T>(iterator: { next: () => {value: T} } | Itera
 export declare function map<T, O>(func: (item: T) => O): (iter: IterableLike<T>) => Iterable<O>;
 export declare function map<T, O>(func: (item: T) => O, iter: IterableLike<T>): Iterable<O>;
 
-export declare function permutations<T, R extends number>(iterable: IterableLike<T>, r: R): Iterable<Repeat<T, R>>;
+export declare const permutations: CombinationsPermutations;
 
 export declare function product<T>(...iterables: Array<IterableLike<T>>): Iterable<T[]>;
 export declare function product<Args extends any[][]>(...iterables: Args): Iterable<ProductReturn<Args>>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "commonjs",
+    "lib": ["es2017", "es2018", "esnext"],
+    "noEmit": true,
+    "declaration": false,
+    "strict": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "pretty": true
+  },
+  "include": [
+    "src/__spec__"
+  ]
+}


### PR DESCRIPTION
### Why?

I had created a change in `index.d.ts` to improve various functions such as `combinations`, basically, it will return `Iterable<[T, T, ...]>` instead of ambiguous `Iterable<T[]>`.

But it comes with a cost: The length of each tuple in the returning iterable depends on `R` (generic type parameter of `r`), it's works fine when `R` is `number` or an integer (or a union of integer) within the range of 0 - 99, but when it isn't, it causes TSC to run into infinite loop.

Therefore, I made this change to make TypeScript treats `R` differently based on its value.

### How would it works?

I created two types: `ReasonableNumber` and `CombinationsPermutations`; `ReasonableNumber` is a union of `0 | 1 | ... | 31`, and `CombinationsPermutations` is type of `combinations`/`permutations` functions.

```typescript
type ReasonableNumber = UnionRange<32>;

type CombinationsPermutations = <T, R extends number>(iterable: IterableLike<T>, r: R) =>
  Iterable<R extends ReasonableNumber ? Repeat<T, R> : number[]>;

declare const combinations: CombinationsPermutations
...
```

When user call these function (like so: `combinations(iterable, r)`), the returning value will have type of:
  * `[T, T, ..., T]` (tuple) when `r: R` is within 0 - 31, the number of elements within tuple depends on value of `r`.
  * `T[]` (unbounded array) when `r: R` is not within 0 - 31 (e.g. `-1`, `2.5`, `1000`, `number`).
  * `[T, T, ..., T] | [T, ...] | ...` (union of tuples) when `R` is a union of number constant within 0 - 31.

### Additional Changes

* This pull request includes https://github.com/sithmel/iter-tools/pull/61 because I don't want to code bindly without tests.

### Additional Requests

* If this were to be merged, it should be published under `rc` tag first. I want to double-check it.

