### PR TITLE
[TypeScript] Fix some types and update tests

### DIFF
--- a/src/__spec__/combinations.spec.ts
+++ b/src/__spec__/combinations.spec.ts
@@ -2,25 +2,25 @@ import assert from "static-type-assert";
 import * as iter from "../index";
 
 assert<
-  Iterable<[number, number, number]>
+  IterableIterator<[number, number, number]>
 >(iter.combinations([0, 1, 2, 3], 3));
 
 assert<
-  Iterable<number[]>
+  IterableIterator<number[]>
 >(iter.combinations([0, 1, 2, 3], Number()));
 
 assert<
-  Iterable<number[]>
+  IterableIterator<number[]>
 >(iter.combinations([0, 1, 2, 3], 999));
 
 assert<
-  Iterable<[string, string, string]>
+  IterableIterator<[string, string, string]>
 >(iter.combinations(iter.iterable(""), 3));
 
 assert<
-  Iterable<[number, number, number, number]>
+  IterableIterator<[number, number, number, number]>
 >(iter.combinations([0, 1, 2, 3] as [number, number, number, number]));
 
 assert<
-  Iterable<string[]>
+  IterableIterator<string[]>
 >(iter.combinations(iter.iterable("")));

--- a/src/__spec__/cycle.spec.ts
+++ b/src/__spec__/cycle.spec.ts
@@ -2,19 +2,19 @@ import assert from "static-type-assert";
 import * as iter from "../index";
 
 assert<
-  Iterable<0 | 1 | 2>
+  IterableIterator<0 | 1 | 2>
 >(iter.cycle([0, 1, 2] as [0, 1, 2]));
 
 assert<
-  Iterable<never> |
-  Iterable<0 | 1> |
-  Iterable<string | number | boolean>
+  IterableIterator<never> |
+  IterableIterator<0 | 1> |
+  IterableIterator<string | number | boolean>
 >(iter.cycle([] as [] | [0, 1] | [string, number, boolean]));
 
 assert<
-  Iterable<string | number | boolean>
+  IterableIterator<string | number | boolean>
 >(iter.cycle([] as [] | [0, 1] | [string, number, boolean]));
 
 assert<
-  Iterable<string>
+  IterableIterator<string>
 >(iter.cycle(iter.iterable("")));

--- a/src/__spec__/execute.spec.ts
+++ b/src/__spec__/execute.spec.ts
@@ -2,33 +2,33 @@ import assert from "static-type-assert";
 import * as iter from "../index";
 
 assert<
-  Iterable<123>
+  IterableIterator<123>
 >(iter.execute(() => 123 as 123));
 
 assert<
-  Iterable<123>
+  IterableIterator<123>
 >(iter.execute((x) => x, 123 as 123, 456 as 456));
 
 assert<
-  Iterable<[]>
+  IterableIterator<[]>
 >(iter.execute((...args) => args));
 
 assert<
-  Iterable<[0, 1, 2]>
+  IterableIterator<[0, 1, 2]>
 >(iter.execute((...args) => args, 0 as 0, 1 as 1, 2 as 2));
 
 assert<
-  AsyncIterable<123>
+  AsyncIterableIterator<123>
 >(iter.asyncExecute(async () => 123 as 123));
 
 assert<
-  AsyncIterable<123>
+  AsyncIterableIterator<123>
 >(iter.asyncExecute(async (x) => x, 123 as 123, 456 as 456));
 
 assert<
-  AsyncIterable<[]>
+  AsyncIterableIterator<[]>
 >(iter.asyncExecute(async (...args) => args));
 
 assert<
-  AsyncIterable<[0, 1, 2]>
+  AsyncIterableIterator<[0, 1, 2]>
 >(iter.asyncExecute(async (...args) => args, 0 as 0, 1 as 1, 2 as 2));

--- a/src/__spec__/permutations.spec.ts
+++ b/src/__spec__/permutations.spec.ts
@@ -2,25 +2,25 @@ import assert from "static-type-assert";
 import * as iter from "../index";
 
 assert<
-  Iterable<[number, number, number]>
+  IterableIterator<[number, number, number]>
 >(iter.permutations([0, 1, 2, 3], 3));
 
 assert<
-  Iterable<number[]>
+  IterableIterator<number[]>
 >(iter.permutations([0, 1, 2, 3], Number()));
 
 assert<
-  Iterable<number[]>
+  IterableIterator<number[]>
 >(iter.permutations([0, 1, 2, 3], 999));
 
 assert<
-  Iterable<[string, string, string]>
+  IterableIterator<[string, string, string]>
 >(iter.permutations(iter.iterable(""), 3));
 
 assert<
-  Iterable<[number, number, number, number]>
+  IterableIterator<[number, number, number, number]>
 >(iter.permutations([0, 1, 2, 3] as [number, number, number, number]));
 
 assert<
-  Iterable<string[]>
+  IterableIterator<string[]>
 >(iter.permutations(iter.iterable("")));

--- a/src/__spec__/product.spec.ts
+++ b/src/__spec__/product.spec.ts
@@ -2,18 +2,18 @@ import assert from "static-type-assert";
 import * as iter from "../index";
 
 assert<
-  Iterable<[0 | 1 | 2, 3 | 4 | 5]>
+  IterableIterator<[0 | 1 | 2, 3 | 4 | 5]>
 >(iter.product(
   [0, 1, 2] as [0, 1, 2],
   [3, 4, 5] as [3, 4, 5]
 ));
 
 assert<
-  Iterable<[number, number, number]>
+  IterableIterator<[number, number, number]>
 >(iter.product([0, 1, 2], [3, 4, 5], [7, 8, 9]));
 
 assert<
-  Iterable<[string, string, string]>
+  IterableIterator<[string, string, string]>
 >(iter.product(
   iter.iterable(""),
   iter.iterable(""),

--- a/src/__spec__/range.spec.ts
+++ b/src/__spec__/range.spec.ts
@@ -2,13 +2,13 @@ import assert from "static-type-assert";
 import * as iter from "../index";
 
 assert<
-  Iterable<0 | 1 | 2>
+  IterableIterator<0 | 1 | 2>
 >(iter.range(3));
 
 assert<
-  Iterable<number>
+  IterableIterator<number>
 >(iter.range(200));
 
 assert<
-  Iterable<number>
+  IterableIterator<number>
 >(iter.range({start: 2}));

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -20,11 +20,11 @@ type CombinationsPermutationsByIterable<Iter extends IterableLike<any>> =
   Iter extends Iterable<infer T>
     ? Iter extends T[]
       ? CombinationsPermutationsByLength<T, Iter["length"]>
-      : Iterable<T[]>
+      : IterableIterator<T[]>
     : never;
 
 type CombinationsPermutationsByLength<T, R extends number> =
-  Iterable<R extends ReasonableNumber ? Repeat<T, R> : T[]>;
+  IterableIterator<R extends ReasonableNumber ? Repeat<T, R> : T[]>;
 
 /**
  * Helper generic for `product` function
@@ -47,7 +47,7 @@ type ProductReturnElement<Args extends Array<Iterable<any>>, Holder extends any[
 ];
 
 type RangeReturn<R extends number> =
-  R extends ReasonableNumber ? Repeat<UnionRange<R>, R> : IterableIterator<number>;
+  IterableIterator<R extends ReasonableNumber ? UnionRange<R> : number>;
 
 // Sync
 export declare function keys(iterable: any): IterableIterator<any>;


### PR DESCRIPTION
* **Fix some types**: I made a mistake in which `repeat` returns an array. I also forgot to fix return types of `combinations`/`permutations`.

* **Update tests**: In the [last pull request](https://github.com/sithmel/iter-tools/pull/66), I made functions return `IteratorIterable` but forgot to update corresponding tests.