### PR TITLE
Use tslint-config-standard instead of tslint:recommended

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7354,6 +7354,65 @@
         "tsutils": "^2.27.2"
       }
     },
+    "tslint-config-standard": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/tslint-config-standard/-/tslint-config-standard-8.0.1.tgz",
+      "integrity": "sha512-OWG+NblgjQlVuUS/Dmq3ax2v5QDZwRx4L0kEuDi7qFY9UI6RJhhNfoCV1qI4el8Fw1c5a5BTrjQJP0/jhGXY/Q==",
+      "dev": true,
+      "requires": {
+        "tslint-eslint-rules": "^5.3.1"
+      }
+    },
+    "tslint-eslint-rules": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-5.4.0.tgz",
+      "integrity": "sha512-WlSXE+J2vY/VPgIcqQuijMQiel+UtmXS+4nvK4ZzlDiqBfXse8FAvkNnTcYhnQyOTW5KFM+uRRGXxYhFpuBc6w==",
+      "dev": true,
+      "requires": {
+        "doctrine": "0.7.2",
+        "tslib": "1.9.0",
+        "tsutils": "^3.0.0"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+          "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
+          "dev": true,
+          "requires": {
+            "esutils": "^1.1.6",
+            "isarray": "0.0.1"
+          }
+        },
+        "esutils": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+          "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "tslib": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+          "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+          "dev": true
+        },
+        "tsutils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.0.0.tgz",
+          "integrity": "sha512-LjHBWR0vWAUHWdIAoTjoqi56Kz+FDKBgVEuL+gVPG/Pv7QW5IdaDDeK9Txlr6U0Cmckp5EgCIq1T25qe3J6hyw==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        }
+      }
+    },
     "tsutils": {
       "version": "2.29.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "require-all": "^2.2.0",
     "rimraf": "^2.6.2",
     "tslint": "^5.11.0",
+    "tslint-config-standard": "^8.0.1",
     "static-type-assert": "^2.0.0",
     "typescript": "^3.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build:es2018": "mkdirp es2018 && copyfiles -f src/*.mjs es2018",
     "build:es2018-cjs": "cross-env BABEL_ENV=es2018-cjs babel -x \".mjs\" src -d es2018",
     "build:copyts": "copyfiles -f src/*.ts es5 && copyfiles -f src/*.ts es2015 && copyfiles -f src/*.ts es2018",
-    "tslint": "tslint -c tslint.json 'src/**/*.ts'",
+    "tslint": "tslint -c tslint.json -p . 'src/**/*.ts'",
     "tslint:fix": "npm run tslint -- --fix",
     "prepublishOnly": "npm run build",
     "precommit": "npm run lint"

--- a/src/__spec__/combinations.spec.ts
+++ b/src/__spec__/combinations.spec.ts
@@ -1,26 +1,26 @@
-import assert from "static-type-assert";
-import * as iter from "../index";
+import assert from 'static-type-assert'
+import * as iter from '../index'
 
 assert<
   IterableIterator<[number, number, number]>
->(iter.combinations([0, 1, 2, 3], 3));
+>(iter.combinations([0, 1, 2, 3], 3))
 
 assert<
   IterableIterator<number[]>
->(iter.combinations([0, 1, 2, 3], Number()));
+>(iter.combinations([0, 1, 2, 3], Number()))
 
 assert<
   IterableIterator<number[]>
->(iter.combinations([0, 1, 2, 3], 999));
+>(iter.combinations([0, 1, 2, 3], 999))
 
 assert<
   IterableIterator<[string, string, string]>
->(iter.combinations(iter.iterable(""), 3));
+>(iter.combinations(iter.iterable(''), 3))
 
 assert<
   IterableIterator<[number, number, number, number]>
->(iter.combinations([0, 1, 2, 3] as [number, number, number, number]));
+>(iter.combinations([0, 1, 2, 3] as [number, number, number, number]))
 
 assert<
   IterableIterator<string[]>
->(iter.combinations(iter.iterable("")));
+>(iter.combinations(iter.iterable('')))

--- a/src/__spec__/cycle.spec.ts
+++ b/src/__spec__/cycle.spec.ts
@@ -1,20 +1,20 @@
-import assert from "static-type-assert";
-import * as iter from "../index";
+import assert from 'static-type-assert'
+import * as iter from '../index'
 
 assert<
   IterableIterator<0 | 1 | 2>
->(iter.cycle([0, 1, 2] as [0, 1, 2]));
+>(iter.cycle([0, 1, 2] as [0, 1, 2]))
 
 assert<
   IterableIterator<never> |
   IterableIterator<0 | 1> |
   IterableIterator<string | number | boolean>
->(iter.cycle([] as [] | [0, 1] | [string, number, boolean]));
+>(iter.cycle([] as [] | [0, 1] | [string, number, boolean]))
 
 assert<
   IterableIterator<string | number | boolean>
->(iter.cycle([] as [] | [0, 1] | [string, number, boolean]));
+>(iter.cycle([] as [] | [0, 1] | [string, number, boolean]))
 
 assert<
   IterableIterator<string>
->(iter.cycle(iter.iterable("")));
+>(iter.cycle(iter.iterable('')))

--- a/src/__spec__/entries.spec.ts
+++ b/src/__spec__/entries.spec.ts
@@ -1,14 +1,14 @@
-import assert from "static-type-assert";
-import * as iter from "../index";
+import assert from 'static-type-assert'
+import * as iter from '../index'
 
 assert<
   IterableIterator<[string, number]>
->(iter.entries({foo: 42}));
+>(iter.entries({ foo: 42 }))
 
 assert<
   IterableIterator<[string, string | null]>
->(iter.entries({foo: "", bar: null}));
+>(iter.entries({ foo: '', bar: null }))
 
 assert<
   IterableIterator<[string, never]>
->(iter.entries({}));
+>(iter.entries({}))

--- a/src/__spec__/execute.spec.ts
+++ b/src/__spec__/execute.spec.ts
@@ -1,34 +1,34 @@
-import assert from "static-type-assert";
-import * as iter from "../index";
+import assert from 'static-type-assert'
+import * as iter from '../index'
 
 assert<
   IterableIterator<123>
->(iter.execute(() => 123 as 123));
+>(iter.execute(() => 123 as 123))
 
 assert<
   IterableIterator<123>
->(iter.execute((x) => x, 123 as 123, 456 as 456));
+>(iter.execute((x) => x, 123 as 123, 456 as 456))
 
 assert<
   IterableIterator<[]>
->(iter.execute((...args) => args));
+>(iter.execute((...args) => args))
 
 assert<
   IterableIterator<[0, 1, 2]>
->(iter.execute((...args) => args, 0 as 0, 1 as 1, 2 as 2));
+>(iter.execute((...args) => args, 0 as 0, 1 as 1, 2 as 2))
 
 assert<
   AsyncIterableIterator<123>
->(iter.asyncExecute(async () => 123 as 123));
+>(iter.asyncExecute(async () => 123 as 123))
 
 assert<
   AsyncIterableIterator<123>
->(iter.asyncExecute(async (x) => x, 123 as 123, 456 as 456));
+>(iter.asyncExecute(async (x) => x, 123 as 123, 456 as 456))
 
 assert<
   AsyncIterableIterator<[]>
->(iter.asyncExecute(async (...args) => args));
+>(iter.asyncExecute(async (...args) => args))
 
 assert<
   AsyncIterableIterator<[0, 1, 2]>
->(iter.asyncExecute(async (...args) => args, 0 as 0, 1 as 1, 2 as 2));
+>(iter.asyncExecute(async (...args) => args, 0 as 0, 1 as 1, 2 as 2))

--- a/src/__spec__/first.spec.ts
+++ b/src/__spec__/first.spec.ts
@@ -1,8 +1,8 @@
-import assert from "static-type-assert";
-import * as iter from "../index";
+import assert from 'static-type-assert'
+import * as iter from '../index'
 
-assert<undefined>(iter.first([]));
-assert<0>(iter.first([0, 1, 2, 3] as [0, 1, 2, 3]));
-assert<number>(iter.first([0, 1, 2] as [number, ...any[]]));
-assert<number | undefined>(iter.first(Array<number>()));
-assert<string | undefined>(iter.first(iter.iterable("")));
+assert<undefined>(iter.first([]))
+assert<0>(iter.first([0, 1, 2, 3] as [0, 1, 2, 3]))
+assert<number>(iter.first([0, 1, 2] as [number, ...any[]]))
+assert<number | undefined>(iter.first(Array<number>()))
+assert<string | undefined>(iter.first(iter.iterable('')))

--- a/src/__spec__/group-by.spec.ts
+++ b/src/__spec__/group-by.spec.ts
@@ -1,60 +1,60 @@
-import assert from "static-type-assert";
-import * as iter from "../index";
+import assert from 'static-type-assert'
+import * as iter from '../index'
 
 assert<
   IterableIterator<[string, IterableIterator<string>]>
->(iter.groupBy(null)("AABBBCC"));
+>(iter.groupBy(null)('AABBBCC'))
 
 assert<
   IterableIterator<[number, IterableIterator<number>]>
->(iter.groupBy(null)([1, 2, 2, 3, 3, 3]));
+>(iter.groupBy(null)([1, 2, 2, 3, 3, 3]))
 
 assert<
   IterableIterator<[string, IterableIterator<string>]>
->(iter.groupBy(null, "AABBBCC"));
+>(iter.groupBy(null, 'AABBBCC'))
 
 assert<
   IterableIterator<[number, IterableIterator<number>]>
->(iter.groupBy(null, [1, 2, 2, 3, 3, 3]));
+>(iter.groupBy(null, [1, 2, 2, 3, 3, 3]))
 
 assert<
   IterableIterator<[string, IterableIterator<number>]>
 >(iter.groupBy(
   (x: number) => String(x)
-)([1, 2, 2, 3, 3, 3]));
+)([1, 2, 2, 3, 3, 3]))
 
 assert<
   IterableIterator<[string, IterableIterator<number>]>
 >(iter.groupBy(
   (x) => String(x),
   [1, 2, 2, 3, 3, 3]
-));
+))
 
 assert<
   AsyncIterableIterator<[string, AsyncIterableIterator<string>]>
->(iter.asyncGroupBy(null)("AABBBCC"));
+>(iter.asyncGroupBy(null)('AABBBCC'))
 
 assert<
 AsyncIterableIterator<[number, AsyncIterableIterator<number>]>
->(iter.asyncGroupBy(null)([1, 2, 2, 3, 3, 3]));
+>(iter.asyncGroupBy(null)([1, 2, 2, 3, 3, 3]))
 
 assert<
   AsyncIterableIterator<[string, AsyncIterableIterator<string>]>
->(iter.asyncGroupBy(null, "AABBBCC"));
+>(iter.asyncGroupBy(null, 'AABBBCC'))
 
 assert<
   AsyncIterableIterator<[number, AsyncIterableIterator<number>]>
->(iter.asyncGroupBy(null, [1, 2, 2, 3, 3, 3]));
+>(iter.asyncGroupBy(null, [1, 2, 2, 3, 3, 3]))
 
 assert<
   AsyncIterableIterator<[string, AsyncIterableIterator<number>]>
 >(iter.asyncGroupBy(
   (x: number) => String(x)
-)([1, 2, 2, 3, 3, 3]));
+)([1, 2, 2, 3, 3, 3]))
 
 assert<
 AsyncIterableIterator<[string, AsyncIterableIterator<number>]>
 >(iter.asyncGroupBy(
   (x) => String(x),
   [1, 2, 2, 3, 3, 3]
-));
+))

--- a/src/__spec__/keys.spec.ts
+++ b/src/__spec__/keys.spec.ts
@@ -1,14 +1,14 @@
-import assert from "static-type-assert";
-import * as iter from "../index";
+import assert from 'static-type-assert'
+import * as iter from '../index'
 
 assert<
   IterableIterator<string>
->(iter.keys({foo: "", bar: null}));
+>(iter.keys({ foo: '', bar: null }))
 
 assert<
   IterableIterator<string>
->(iter.keys({}));
+>(iter.keys({}))
 
 assert<
   IterableIterator<string>
->(iter.keys({0: "", 1: null}));
+>(iter.keys({ 0: '', 1: null }))

--- a/src/__spec__/permutations.spec.ts
+++ b/src/__spec__/permutations.spec.ts
@@ -1,26 +1,26 @@
-import assert from "static-type-assert";
-import * as iter from "../index";
+import assert from 'static-type-assert'
+import * as iter from '../index'
 
 assert<
   IterableIterator<[number, number, number]>
->(iter.permutations([0, 1, 2, 3], 3));
+>(iter.permutations([0, 1, 2, 3], 3))
 
 assert<
   IterableIterator<number[]>
->(iter.permutations([0, 1, 2, 3], Number()));
+>(iter.permutations([0, 1, 2, 3], Number()))
 
 assert<
   IterableIterator<number[]>
->(iter.permutations([0, 1, 2, 3], 999));
+>(iter.permutations([0, 1, 2, 3], 999))
 
 assert<
   IterableIterator<[string, string, string]>
->(iter.permutations(iter.iterable(""), 3));
+>(iter.permutations(iter.iterable(''), 3))
 
 assert<
   IterableIterator<[number, number, number, number]>
->(iter.permutations([0, 1, 2, 3] as [number, number, number, number]));
+>(iter.permutations([0, 1, 2, 3] as [number, number, number, number]))
 
 assert<
   IterableIterator<string[]>
->(iter.permutations(iter.iterable("")));
+>(iter.permutations(iter.iterable('')))

--- a/src/__spec__/product.spec.ts
+++ b/src/__spec__/product.spec.ts
@@ -1,21 +1,21 @@
-import assert from "static-type-assert";
-import * as iter from "../index";
+import assert from 'static-type-assert'
+import * as iter from '../index'
 
 assert<
   IterableIterator<[0 | 1 | 2, 3 | 4 | 5]>
 >(iter.product(
   [0, 1, 2] as [0, 1, 2],
   [3, 4, 5] as [3, 4, 5]
-));
+))
 
 assert<
   IterableIterator<[number, number, number]>
->(iter.product([0, 1, 2], [3, 4, 5], [7, 8, 9]));
+>(iter.product([0, 1, 2], [3, 4, 5], [7, 8, 9]))
 
 assert<
   IterableIterator<[string, string, string]>
 >(iter.product(
-  iter.iterable(""),
-  iter.iterable(""),
-  iter.iterable("")
-));
+  iter.iterable(''),
+  iter.iterable(''),
+  iter.iterable('')
+))

--- a/src/__spec__/range.spec.ts
+++ b/src/__spec__/range.spec.ts
@@ -1,14 +1,14 @@
-import assert from "static-type-assert";
-import * as iter from "../index";
+import assert from 'static-type-assert'
+import * as iter from '../index'
 
 assert<
   IterableIterator<0 | 1 | 2>
->(iter.range(3));
+>(iter.range(3))
 
 assert<
   IterableIterator<number>
->(iter.range(200));
+>(iter.range(200))
 
 assert<
   IterableIterator<number>
->(iter.range({start: 2}));
+>(iter.range({ start: 2 }))

--- a/src/__spec__/size.spec.ts
+++ b/src/__spec__/size.spec.ts
@@ -1,7 +1,7 @@
-import assert from "static-type-assert";
-import * as iter from "../index";
+import assert from 'static-type-assert'
+import * as iter from '../index'
 
-assert<4>(iter.size([0, 1, 2, 3] as [0, 1, 2, 3]));
-assert<0 | 1 | 2>(iter.size([] as [] | [number] | [number, number]));
-assert<number>(iter.size([0, 1, 2, 3]));
-assert<number>(iter.size(iter.iterable("")));
+assert<4>(iter.size([0, 1, 2, 3] as [0, 1, 2, 3]))
+assert<0 | 1 | 2>(iter.size([] as [] | [number] | [number, number]))
+assert<number>(iter.size([0, 1, 2, 3]))
+assert<number>(iter.size(iter.iterable('')))

--- a/src/__spec__/values.spec.ts
+++ b/src/__spec__/values.spec.ts
@@ -1,14 +1,14 @@
-import assert from "static-type-assert";
-import * as iter from "../index";
+import assert from 'static-type-assert'
+import * as iter from '../index'
 
 assert<
   IterableIterator<number>
->(iter.values({foo: 42}));
+>(iter.values({ foo: 42 }))
 
 assert<
   IterableIterator<string | null>
->(iter.values({foo: "", bar: null}));
+>(iter.values({ foo: '', bar: null }))
 
 assert<
   IterableIterator<never>
->(iter.values({}));
+>(iter.values({}))

--- a/src/async-batch.d.ts
+++ b/src/async-batch.d.ts
@@ -1,2 +1,2 @@
-import { asyncBatch } from "./index";
-export = asyncBatch;
+import { asyncBatch } from './index'
+export = asyncBatch

--- a/src/async-buffer.d.ts
+++ b/src/async-buffer.d.ts
@@ -1,2 +1,2 @@
-import { asyncBuffer } from "./index";
-export = asyncBuffer;
+import { asyncBuffer } from './index'
+export = asyncBuffer

--- a/src/async-chain.d.ts
+++ b/src/async-chain.d.ts
@@ -1,2 +1,2 @@
-import { asyncChain } from "./index";
-export = asyncChain;
+import { asyncChain } from './index'
+export = asyncChain

--- a/src/async-compress.d.ts
+++ b/src/async-compress.d.ts
@@ -1,2 +1,2 @@
-import { asyncCompress } from "./index";
-export = asyncCompress;
+import { asyncCompress } from './index'
+export = asyncCompress

--- a/src/async-concat.d.ts
+++ b/src/async-concat.d.ts
@@ -1,2 +1,2 @@
-import { asyncConcat } from "./index";
-export = asyncConcat;
+import { asyncConcat } from './index'
+export = asyncConcat

--- a/src/async-consume.d.ts
+++ b/src/async-consume.d.ts
@@ -1,2 +1,2 @@
-import { asyncConsume } from "./index";
-export = asyncConsume;
+import { asyncConsume } from './index'
+export = asyncConsume

--- a/src/async-cycle.d.ts
+++ b/src/async-cycle.d.ts
@@ -1,2 +1,2 @@
-import { asyncCycle } from "./index";
-export = asyncCycle;
+import { asyncCycle } from './index'
+export = asyncCycle

--- a/src/async-drop-while.d.ts
+++ b/src/async-drop-while.d.ts
@@ -1,2 +1,2 @@
-import { asyncDropWhile } from "./index";
-export = asyncDropWhile;
+import { asyncDropWhile } from './index'
+export = asyncDropWhile

--- a/src/async-enumerate.d.ts
+++ b/src/async-enumerate.d.ts
@@ -1,2 +1,2 @@
-import { asyncEnumerate } from "./index";
-export = asyncEnumerate;
+import { asyncEnumerate } from './index'
+export = asyncEnumerate

--- a/src/async-every.d.ts
+++ b/src/async-every.d.ts
@@ -1,2 +1,2 @@
-import { asyncEvery } from "./index";
-export = asyncEvery;
+import { asyncEvery } from './index'
+export = asyncEvery

--- a/src/async-execute.d.ts
+++ b/src/async-execute.d.ts
@@ -1,2 +1,2 @@
-import { asyncExecute } from "./index";
-export = asyncExecute;
+import { asyncExecute } from './index'
+export = asyncExecute

--- a/src/async-filter.d.ts
+++ b/src/async-filter.d.ts
@@ -1,2 +1,2 @@
-import { asyncFilter } from "./index";
-export = asyncFilter;
+import { asyncFilter } from './index'
+export = asyncFilter

--- a/src/async-find.d.ts
+++ b/src/async-find.d.ts
@@ -1,2 +1,2 @@
-import { asyncFind } from "./index";
-export = asyncFind;
+import { asyncFind } from './index'
+export = asyncFind

--- a/src/async-first.d.ts
+++ b/src/async-first.d.ts
@@ -1,2 +1,2 @@
-import { asyncFirst } from "./index";
-export = asyncFirst;
+import { asyncFirst } from './index'
+export = asyncFirst

--- a/src/async-flat-map.d.ts
+++ b/src/async-flat-map.d.ts
@@ -1,2 +1,2 @@
-import { asyncFlatMap } from "./index";
-export = asyncFlatMap;
+import { asyncFlatMap } from './index'
+export = asyncFlatMap

--- a/src/async-group-by.d.ts
+++ b/src/async-group-by.d.ts
@@ -1,2 +1,2 @@
-import { asyncGroupBy } from "./index";
-export = asyncGroupBy;
+import { asyncGroupBy } from './index'
+export = asyncGroupBy

--- a/src/async-iter.d.ts
+++ b/src/async-iter.d.ts
@@ -1,2 +1,2 @@
-import { asyncIter } from "./index";
-export = asyncIter;
+import { asyncIter } from './index'
+export = asyncIter

--- a/src/async-iterable.d.ts
+++ b/src/async-iterable.d.ts
@@ -1,2 +1,2 @@
-import { asyncIterable } from "./index";
-export = asyncIterable;
+import { asyncIterable } from './index'
+export = asyncIterable

--- a/src/async-map.d.ts
+++ b/src/async-map.d.ts
@@ -1,2 +1,2 @@
-import { asyncMap } from "./index";
-export = asyncMap;
+import { asyncMap } from './index'
+export = asyncMap

--- a/src/async-reduce.d.ts
+++ b/src/async-reduce.d.ts
@@ -1,2 +1,2 @@
-import { asyncReduce } from "./index";
-export = asyncReduce;
+import { asyncReduce } from './index'
+export = asyncReduce

--- a/src/async-regexp-exec-iter.d.ts
+++ b/src/async-regexp-exec-iter.d.ts
@@ -1,2 +1,2 @@
-import { asyncRegexpExecIter } from "./index";
-export = asyncRegexpExecIter;
+import { asyncRegexpExecIter } from './index'
+export = asyncRegexpExecIter

--- a/src/async-regexp-split-iter.d.ts
+++ b/src/async-regexp-split-iter.d.ts
@@ -1,2 +1,2 @@
-import { asyncRegexpSplitIter } from "./index";
-export = asyncRegexpSplitIter;
+import { asyncRegexpSplitIter } from './index'
+export = asyncRegexpSplitIter

--- a/src/async-size.d.ts
+++ b/src/async-size.d.ts
@@ -1,2 +1,2 @@
-import { asyncSize } from "./index";
-export = asyncSize;
+import { asyncSize } from './index'
+export = asyncSize

--- a/src/async-slice.d.ts
+++ b/src/async-slice.d.ts
@@ -1,2 +1,2 @@
-import { asyncSlice } from "./index";
-export = asyncSlice;
+import { asyncSlice } from './index'
+export = asyncSlice

--- a/src/async-some.d.ts
+++ b/src/async-some.d.ts
@@ -1,2 +1,2 @@
-import { asyncSome } from "./index";
-export = asyncSome;
+import { asyncSome } from './index'
+export = asyncSome

--- a/src/async-split-lines.d.ts
+++ b/src/async-split-lines.d.ts
@@ -1,2 +1,2 @@
-import { asyncSplitLines } from "./index";
-export = asyncSplitLines;
+import { asyncSplitLines } from './index'
+export = asyncSplitLines

--- a/src/async-tak-sorted.d.ts
+++ b/src/async-tak-sorted.d.ts
@@ -1,2 +1,2 @@
-import { asyncTakeSorted } from "./index";
-export = asyncTakeSorted;
+import { asyncTakeSorted } from './index'
+export = asyncTakeSorted

--- a/src/async-take-while.d.ts
+++ b/src/async-take-while.d.ts
@@ -1,2 +1,2 @@
-import { asyncTakeWhile } from "./index";
-export = asyncTakeWhile;
+import { asyncTakeWhile } from './index'
+export = asyncTakeWhile

--- a/src/async-tap.d.ts
+++ b/src/async-tap.d.ts
@@ -1,2 +1,2 @@
-import { asyncTap } from "./index";
-export = asyncTap;
+import { asyncTap } from './index'
+export = asyncTap

--- a/src/async-tee.d.ts
+++ b/src/async-tee.d.ts
@@ -1,2 +1,2 @@
-import { asyncTee } from "./index";
-export = asyncTee;
+import { asyncTee } from './index'
+export = asyncTee

--- a/src/async-throttle.d.ts
+++ b/src/async-throttle.d.ts
@@ -1,2 +1,2 @@
-import { asyncThrottle } from "./index";
-export = asyncThrottle;
+import { asyncThrottle } from './index'
+export = asyncThrottle

--- a/src/async-to-array.d.ts
+++ b/src/async-to-array.d.ts
@@ -1,2 +1,2 @@
-import { asyncToArray } from "./index";
-export = asyncToArray;
+import { asyncToArray } from './index'
+export = asyncToArray

--- a/src/async-zip-all.d.ts
+++ b/src/async-zip-all.d.ts
@@ -1,2 +1,2 @@
-import { asyncZipAll } from "./index";
-export = asyncZipAll;
+import { asyncZipAll } from './index'
+export = asyncZipAll

--- a/src/async-zip-longest.d.ts
+++ b/src/async-zip-longest.d.ts
@@ -1,2 +1,2 @@
-import { asyncZipLongest } from "./index";
-export = asyncZipLongest;
+import { asyncZipLongest } from './index'
+export = asyncZipLongest

--- a/src/async-zip.d.ts
+++ b/src/async-zip.d.ts
@@ -1,2 +1,2 @@
-import { asyncZip } from "./index";
-export = asyncZip;
+import { asyncZip } from './index'
+export = asyncZip

--- a/src/batch.d.ts
+++ b/src/batch.d.ts
@@ -1,2 +1,2 @@
-import { batch } from "./index";
-export = batch;
+import { batch } from './index'
+export = batch

--- a/src/chain.d.ts
+++ b/src/chain.d.ts
@@ -1,2 +1,2 @@
-import { chain } from "./index";
-export = chain;
+import { chain } from './index'
+export = chain

--- a/src/combinations-with-replacement.d.ts
+++ b/src/combinations-with-replacement.d.ts
@@ -1,2 +1,2 @@
-import { combinationsWithReplacement } from "./index";
-export = combinationsWithReplacement;
+import { combinationsWithReplacement } from './index'
+export = combinationsWithReplacement

--- a/src/combinations.d.ts
+++ b/src/combinations.d.ts
@@ -1,2 +1,2 @@
-import { combinations } from "./index";
-export = combinations;
+import { combinations } from './index'
+export = combinations

--- a/src/compose.d.ts
+++ b/src/compose.d.ts
@@ -1,2 +1,2 @@
-import { compose } from "./index";
-export = compose;
+import { compose } from './index'
+export = compose

--- a/src/compress.d.ts
+++ b/src/compress.d.ts
@@ -1,2 +1,2 @@
-import { compress } from "./index";
-export = compress;
+import { compress } from './index'
+export = compress

--- a/src/concat.d.ts
+++ b/src/concat.d.ts
@@ -1,2 +1,2 @@
-import { concat } from "./index";
-export = concat;
+import { concat } from './index'
+export = concat

--- a/src/consume.d.ts
+++ b/src/consume.d.ts
@@ -1,2 +1,2 @@
-import { consume } from "./index";
-export = consume;
+import { consume } from './index'
+export = consume

--- a/src/count.d.ts
+++ b/src/count.d.ts
@@ -1,2 +1,2 @@
-import { count } from "./index";
-export = count;
+import { count } from './index'
+export = count

--- a/src/cycle.d.ts
+++ b/src/cycle.d.ts
@@ -1,2 +1,2 @@
-import { cycle } from "./index";
-export = cycle;
+import { cycle } from './index'
+export = cycle

--- a/src/drop-while.d.ts
+++ b/src/drop-while.d.ts
@@ -1,2 +1,2 @@
-import { dropWhile } from "./index";
-export = dropWhile;
+import { dropWhile } from './index'
+export = dropWhile

--- a/src/entries.d.ts
+++ b/src/entries.d.ts
@@ -1,2 +1,2 @@
-import { entries } from "./index";
-export = entries;
+import { entries } from './index'
+export = entries

--- a/src/enumerate.d.ts
+++ b/src/enumerate.d.ts
@@ -1,2 +1,2 @@
-import { enumerate } from "./index";
-export = enumerate;
+import { enumerate } from './index'
+export = enumerate

--- a/src/every.d.ts
+++ b/src/every.d.ts
@@ -1,2 +1,2 @@
-import { every } from "./index";
-export = every;
+import { every } from './index'
+export = every

--- a/src/execute.d.ts
+++ b/src/execute.d.ts
@@ -1,2 +1,2 @@
-import { execute } from "./index";
-export = execute;
+import { execute } from './index'
+export = execute

--- a/src/filter.d.ts
+++ b/src/filter.d.ts
@@ -1,2 +1,2 @@
-import { filter } from "./index";
-export = filter;
+import { filter } from './index'
+export = filter

--- a/src/find.d.ts
+++ b/src/find.d.ts
@@ -1,2 +1,2 @@
-import { find } from "./index";
-export = find;
+import { find } from './index'
+export = find

--- a/src/first.d.ts
+++ b/src/first.d.ts
@@ -1,2 +1,2 @@
-import { first } from "./index";
-export = first;
+import { first } from './index'
+export = first

--- a/src/flat-map.d.ts
+++ b/src/flat-map.d.ts
@@ -1,2 +1,2 @@
-import { flatMap } from "./index";
-export = flatMap;
+import { flatMap } from './index'
+export = flatMap

--- a/src/group-by.d.ts
+++ b/src/group-by.d.ts
@@ -1,2 +1,2 @@
-import { groupBy } from "./index";
-export = groupBy;
+import { groupBy } from './index'
+export = groupBy

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,7 +10,7 @@ type ReasonableNumber = UnionRange<32>
 /**
  * Function signature of `permutations` and `combinations`
  */
-interface ICombinationsPermutations {
+interface CombinationsPermutations {
   <Iter extends Iterable<any>>(iterable: Iter, r?: undefined): CombinationsPermutationsByIterable<Iter>
   <T, R extends number>(iterable: Iterable<T>, r: R): CombinationsPermutationsByLength<T, R>
 }
@@ -59,8 +59,8 @@ export declare function batch<T> (n: number, iterable: Iterable<T>): IterableIte
 export declare function chain<T> (...iterables: Array<Iterable<T>>): IterableIterator<T>
 export declare function concat<T> (...iterables: Array<Iterable<T>>): IterableIterator<T>
 
-export declare const combinations: ICombinationsPermutations
-export declare const combinationsWithReplacement: ICombinationsPermutations
+export declare const combinations: CombinationsPermutations
+export declare const combinationsWithReplacement: CombinationsPermutations
 
 export declare function compose<T> (fns: Iterable<(_: T) => T>): IterableIterator<T>
 
@@ -124,7 +124,7 @@ export declare function iterable<T> (iterator: { next: () => {value: T} } | Iter
 export declare function map<T, O> (func: (item: T) => O): (iter: Iterable<T>) => IterableIterator<O>
 export declare function map<T, O> (func: (item: T) => O, iter: Iterable<T>): IterableIterator<O>
 
-export declare const permutations: ICombinationsPermutations
+export declare const permutations: CombinationsPermutations
 
 export declare function product<Args extends Array<Iterable<any>>> (...iterables: Args):
   IterableIterator<ProductReturnElement<Args>>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,29 +1,29 @@
 /// <reference lib="es2018" />
 /// <reference lib="esnext.asynciterable" />
 
-import { IsFinite, Prepend, Repeat, Reverse } from "typescript-tuple";
-import { FromTuple as UnionFromTuple, RangeZero as UnionRange } from "typescript-union";
+import { IsFinite, Prepend, Repeat, Reverse } from 'typescript-tuple'
+import { FromTuple as UnionFromTuple, RangeZero as UnionRange } from 'typescript-union'
 
-type AsyncIterableLike<T> = AsyncIterable<T> | Iterable<T>;
-type ReasonableNumber = UnionRange<32>;
+type AsyncIterableLike<T> = AsyncIterable<T> | Iterable<T>
+type ReasonableNumber = UnionRange<32>
 
 /**
  * Function signature of `permutations` and `combinations`
  */
 interface ICombinationsPermutations {
-  <Iter extends Iterable<any>>(iterable: Iter, r?: undefined): CombinationsPermutationsByIterable<Iter>;
-  <T, R extends number>(iterable: Iterable<T>, r: R): CombinationsPermutationsByLength<T, R>;
+  <Iter extends Iterable<any>>(iterable: Iter, r?: undefined): CombinationsPermutationsByIterable<Iter>
+  <T, R extends number>(iterable: Iterable<T>, r: R): CombinationsPermutationsByLength<T, R>
 }
 
 type CombinationsPermutationsByIterable<Iter extends Iterable<any>> =
   Iter extends Iterable<infer T>
     ? Iter extends T[]
-      ? CombinationsPermutationsByLength<T, Iter["length"]>
+      ? CombinationsPermutationsByLength<T, Iter['length']>
       : IterableIterator<T[]>
-    : never;
+    : never
 
 type CombinationsPermutationsByLength<T, R extends number> =
-  IterableIterator<R extends ReasonableNumber ? Repeat<T, R> : T[]>;
+  IterableIterator<R extends ReasonableNumber ? Repeat<T, R> : T[]>
 
 /**
  * Helper generic for `product` function
@@ -42,285 +42,285 @@ type ProductReturnElement<Args extends Array<Iterable<any>>, Holder extends any[
     : never,
   infinite: Args extends Array<Array<infer T>> ? T[] : never
 }[
-  Args extends [] ? "empty" : IsFinite<Args, "many", "infinite">
-];
+  Args extends [] ? 'empty' : IsFinite<Args, 'many', 'infinite'>
+]
 
 type RangeReturn<R extends number> =
-  IterableIterator<R extends ReasonableNumber ? UnionRange<R> : number>;
+  IterableIterator<R extends ReasonableNumber ? UnionRange<R> : number>
 
 // Sync
-export declare function keys(obj: { [id: string]: any }): IterableIterator<string>;
-export declare function values<T>(obj: { [id: string]: T }): IterableIterator<T>;
-export declare function entries<T>(obj: { [id: string]: T }): IterableIterator<[string, T]>;
+export declare function keys (obj: { [id: string]: any }): IterableIterator<string>
+export declare function values<T> (obj: { [id: string]: T }): IterableIterator<T>
+export declare function entries<T> (obj: { [id: string]: T }): IterableIterator<[string, T]>
 
-export declare function batch<T>(n: number): (iterable: Iterable<T>) => IterableIterator<T[]>;
-export declare function batch<T>(n: number, iterable: Iterable<T>): IterableIterator<T[]>;
+export declare function batch<T> (n: number): (iterable: Iterable<T>) => IterableIterator<T[]>
+export declare function batch<T> (n: number, iterable: Iterable<T>): IterableIterator<T[]>
 
-export declare function chain<T>(...iterables: Array<Iterable<T>>): IterableIterator<T>;
-export declare function concat<T>(...iterables: Array<Iterable<T>>): IterableIterator<T>;
+export declare function chain<T> (...iterables: Array<Iterable<T>>): IterableIterator<T>
+export declare function concat<T> (...iterables: Array<Iterable<T>>): IterableIterator<T>
 
-export declare const combinations: ICombinationsPermutations;
-export declare const combinationsWithReplacement: ICombinationsPermutations;
+export declare const combinations: ICombinationsPermutations
+export declare const combinationsWithReplacement: ICombinationsPermutations
 
-export declare function compose<T>(fns: Iterable<(_: T) => T>): IterableIterator<T>;
+export declare function compose<T> (fns: Iterable<(_: T) => T>): IterableIterator<T>
 
-export declare function compress<T>(iterable: Iterable<T>, compress: Iterable<boolean>): IterableIterator<T>;
+export declare function compress<T> (iterable: Iterable<T>, compress: Iterable<boolean>): IterableIterator<T>
 
-export declare function consume<T>(func: (item: T) => void): (iterable: Iterable<T>) => void;
-export declare function consume<T>(func: (item: T) => void, iterable: Iterable<T>): void;
+export declare function consume<T> (func: (item: T) => void): (iterable: Iterable<T>) => void
+export declare function consume<T> (func: (item: T) => void, iterable: Iterable<T>): void
 
-export declare function count(opts: number | { start: number, end?: number, step?: number }): IterableIterator<number>;
+export declare function count (opts: number | { start: number, end?: number, step?: number }): IterableIterator<number>
 
-export declare function cycle<Iter extends Iterable<any>>(iterable: Iter):
-  Iter extends any[] ? IterableIterator<UnionFromTuple<Iter>> : Iter;
+export declare function cycle<Iter extends Iterable<any>> (iterable: Iter):
+  Iter extends any[] ? IterableIterator<UnionFromTuple<Iter>> : Iter
 
-export declare function dropWhile<T>(func: (item: T) => boolean): (iterable: Iterable<T>) => IterableIterator<T>;
-export declare function dropWhile<T>(func: (item: T) => boolean, iterable: Iterable<T>): IterableIterator<T>;
+export declare function dropWhile<T> (func: (item: T) => boolean): (iterable: Iterable<T>) => IterableIterator<T>
+export declare function dropWhile<T> (func: (item: T) => boolean, iterable: Iterable<T>): IterableIterator<T>
 
-export declare function enumerate<T>(iterable: Iterable<T>, start?: number): IterableIterator<[number, T]>;
+export declare function enumerate<T> (iterable: Iterable<T>, start?: number): IterableIterator<[number, T]>
 
-export declare function execute<T, Args extends any[] = any[]>(
+export declare function execute<T, Args extends any[] = any[]> (
   func: (...args: Args) => T,
   ...args: Args
-): IterableIterator<T>;
+): IterableIterator<T>
 
-export declare function every<T>(func: (item: T) => boolean): (iterable: Iterable<T>) => boolean;
-export declare function every<T>(func: (item: T) => boolean, iterable: Iterable<T>): boolean;
+export declare function every<T> (func: (item: T) => boolean): (iterable: Iterable<T>) => boolean
+export declare function every<T> (func: (item: T) => boolean, iterable: Iterable<T>): boolean
 
-export declare function filter<T>(func: (item: T) => boolean): (iterable: Iterable<T>) => IterableIterator<T>;
-export declare function filter<T>(func: (item: T) => boolean, iterable: Iterable<T>): IterableIterator<T>;
+export declare function filter<T> (func: (item: T) => boolean): (iterable: Iterable<T>) => IterableIterator<T>
+export declare function filter<T> (func: (item: T) => boolean, iterable: Iterable<T>): IterableIterator<T>
 
-export declare function find<T>(func: (item: T) => boolean): (iterable: Iterable<T>) => T | null;
-export declare function find<T>(func: (item: T) => boolean, iterable: Iterable<T>): T | null;
+export declare function find<T> (func: (item: T) => boolean): (iterable: Iterable<T>) => T | null
+export declare function find<T> (func: (item: T) => boolean, iterable: Iterable<T>): T | null
 
-export declare function first<Iter extends Iterable<any>>(iterable: Iter):
+export declare function first<Iter extends Iterable<any>> (iterable: Iter):
   Iter extends [] ? undefined :
   Iter extends [infer First, ...any[]] ? First :
   Iter extends Iterable<infer T> ? T | undefined :
-  never;
+  never
 
-export declare function flatMap<T, O>(func: (item: T) => Iterable<O>):
-  (iter: Iterable<T>) => IterableIterator<O>;
-export declare function flatMap<T, O>(
+export declare function flatMap<T, O> (func: (item: T) => Iterable<O>):
+  (iter: Iterable<T>) => IterableIterator<O>
+export declare function flatMap<T, O> (
   func: (item: T) => Iterable<O>,
   iter: Iterable<T>
-): IterableIterator<O>;
+): IterableIterator<O>
 
-export declare function groupBy(key: null):
-  <T>(iterable: Iterable<T>) => IterableIterator<[T, IterableIterator<T>]>;
-export declare function groupBy<T>(
+export declare function groupBy (key: null):
+  <T>(iterable: Iterable<T>) => IterableIterator<[T, IterableIterator<T>]>
+export declare function groupBy<T> (
   key: null,
   iterable: Iterable<T>
-): IterableIterator<[T, IterableIterator<T>]>;
-export declare function groupBy<T, K>(key: (item: T) => K):
-  (iterable: Iterable<T>) => IterableIterator<[K, IterableIterator<T>]>;
-export declare function groupBy<T, K>(
+): IterableIterator<[T, IterableIterator<T>]>
+export declare function groupBy<T, K> (key: (item: T) => K):
+  (iterable: Iterable<T>) => IterableIterator<[K, IterableIterator<T>]>
+export declare function groupBy<T, K> (
   key: (item: T) => K,
   iterable: Iterable<T>
-): IterableIterator<[K, IterableIterator<T>]>;
+): IterableIterator<[K, IterableIterator<T>]>
 
-export declare function iterable<T>(iterator: { next: () => {value: T} } | Iterable<T>): IterableIterator<T>;
+export declare function iterable<T> (iterator: { next: () => {value: T} } | Iterable<T>): IterableIterator<T>
 
-export declare function map<T, O>(func: (item: T) => O): (iter: Iterable<T>) => IterableIterator<O>;
-export declare function map<T, O>(func: (item: T) => O, iter: Iterable<T>): IterableIterator<O>;
+export declare function map<T, O> (func: (item: T) => O): (iter: Iterable<T>) => IterableIterator<O>
+export declare function map<T, O> (func: (item: T) => O, iter: Iterable<T>): IterableIterator<O>
 
-export declare const permutations: ICombinationsPermutations;
+export declare const permutations: ICombinationsPermutations
 
-export declare function product<Args extends Array<Iterable<any>>>(...iterables: Args):
-  IterableIterator<ProductReturnElement<Args>>;
+export declare function product<Args extends Array<Iterable<any>>> (...iterables: Args):
+  IterableIterator<ProductReturnElement<Args>>
 
-export declare function range<R extends number>(r: R): RangeReturn<R>;
-export declare function range(opts: { start: number, end?: number, step?: number }): IterableIterator<number>;
+export declare function range<R extends number> (r: R): RangeReturn<R>
+export declare function range (opts: { start: number, end?: number, step?: number }): IterableIterator<number>
 
-export declare function reduce<T, O>(func: (acc: O, item: T, c: number) => O): (iterable: Iterable<T>) => O;
-export declare function reduce<T, O>(initial: O, func: (acc: O, item: T, c: number) => O):
-    (iterable: Iterable<T>) => O;
-export declare function reduce<T, O>(func: (acc: O, item: T, c: number) => O, iterable: Iterable<T>): O;
-export declare function reduce<T, O>(initial: O, func: (acc: O, item: T, c: number) => O, iterable: Iterable<T>): O;
+export declare function reduce<T, O> (func: (acc: O, item: T, c: number) => O): (iterable: Iterable<T>) => O
+export declare function reduce<T, O> (initial: O, func: (acc: O, item: T, c: number) => O):
+    (iterable: Iterable<T>) => O
+export declare function reduce<T, O> (func: (acc: O, item: T, c: number) => O, iterable: Iterable<T>): O
+export declare function reduce<T, O> (initial: O, func: (acc: O, item: T, c: number) => O, iterable: Iterable<T>): O
 
-export declare function regexpExec(re: RegExp): (str: string) => IterableIterator<string>;
-export declare function regexpExec(re: RegExp, str: string): IterableIterator<string>;
+export declare function regexpExec (re: RegExp): (str: string) => IterableIterator<string>
+export declare function regexpExec (re: RegExp, str: string): IterableIterator<string>
 
-export declare function regexpSplit(re: RegExp): (str: string) => IterableIterator<string>;
-export declare function regexpSplit(re: RegExp, str: string): IterableIterator<string>;
+export declare function regexpSplit (re: RegExp): (str: string) => IterableIterator<string>
+export declare function regexpSplit (re: RegExp, str: string): IterableIterator<string>
 
-export declare function regexpSplitIter(re: RegExp): (iterable: Iterable<string>) => IterableIterator<string>;
-export declare function regexpSplitIter(re: RegExp, iterable: Iterable<string>): IterableIterator<string>;
+export declare function regexpSplitIter (re: RegExp): (iterable: Iterable<string>) => IterableIterator<string>
+export declare function regexpSplitIter (re: RegExp, iterable: Iterable<string>): IterableIterator<string>
 
-export declare function regexpExecIter(re: RegExp): (iterable: Iterable<string>) => IterableIterator<string>;
-export declare function regexpExecIter(re: RegExp, iterable: Iterable<string>): IterableIterator<string>;
+export declare function regexpExecIter (re: RegExp): (iterable: Iterable<string>) => IterableIterator<string>
+export declare function regexpExecIter (re: RegExp, iterable: Iterable<string>): IterableIterator<string>
 
-export declare function splitLines(iterable: Iterable<string>): IterableIterator<string>;
+export declare function splitLines (iterable: Iterable<string>): IterableIterator<string>
 
-export declare function repeat<T>(obj: T, times?: number): IterableIterator<T>;
+export declare function repeat<T> (obj: T, times?: number): IterableIterator<T>
 
-export declare function size<Iter extends Iterable<any>>(iterable: Iter):
-  Iter extends any[] ? Iter["length"] : number;
+export declare function size<Iter extends Iterable<any>> (iterable: Iter):
+  Iter extends any[] ? Iter['length'] : number
 
-export declare function slice<T>(
+export declare function slice<T> (
     opts: number | { start: number, end?: number, step?: number },
-    iterable: Iterable<T>,
-): IterableIterator<number>;
+    iterable: Iterable<T>
+): IterableIterator<number>
 
-export declare function some<T>(func: (item: T) => boolean): (iterable: Iterable<T>) => boolean;
-export declare function some<T>(func: (item: T) => boolean, iterable: Iterable<T>): boolean;
+export declare function some<T> (func: (item: T) => boolean): (iterable: Iterable<T>) => boolean
+export declare function some<T> (func: (item: T) => boolean, iterable: Iterable<T>): boolean
 
-export declare function takeWhile<T>(func: (item: T) => boolean): (iterable: Iterable<T>) => IterableIterator<T>;
-export declare function takeWhile<T>(func: (item: T) => boolean, iterable: Iterable<T>): IterableIterator<T>;
+export declare function takeWhile<T> (func: (item: T) => boolean): (iterable: Iterable<T>) => IterableIterator<T>
+export declare function takeWhile<T> (func: (item: T) => boolean, iterable: Iterable<T>): IterableIterator<T>
 
-export declare function tap<T>(func: (item: T, c: number) => any, iterable: Iterable<T>): IterableIterator<T>;
+export declare function tap<T> (func: (item: T, c: number) => any, iterable: Iterable<T>): IterableIterator<T>
 
-export declare function takeSorted<T>(
+export declare function takeSorted<T> (
+    n: number,
+    func?: (item: T) => boolean
+): (iterable: Iterable<T>) => IterableIterator<T>
+export declare function takeSorted<T> (
     n: number,
     func?: (item: T) => boolean,
-): (iterable: Iterable<T>) => IterableIterator<T>;
-export declare function takeSorted<T>(
-    n: number,
-    func?: (item: T) => boolean,
-    iterable?: Iterable<T>,
-): IterableIterator<T>;
+    iterable?: Iterable<T>
+): IterableIterator<T>
 
-export declare function tee<T>(iterable: Iterable<T>, n?: number): Array<IterableIterator<T>>;
+export declare function tee<T> (iterable: Iterable<T>, n?: number): Array<IterableIterator<T>>
 
-export declare function toArray<T>(iterable: Iterable<T>): T[];
+export declare function toArray<T> (iterable: Iterable<T>): T[]
 
-export declare function zipLongest<T>(...iterables: Array<Iterable<T>>): IterableIterator<T[]>;
-export declare function zipAll<T>(...iterables: Array<Iterable<T>>): IterableIterator<T[]>;
-export declare function zip<T>(...iterables: Array<Iterable<T>>): IterableIterator<T[]>;
+export declare function zipLongest<T> (...iterables: Array<Iterable<T>>): IterableIterator<T[]>
+export declare function zipAll<T> (...iterables: Array<Iterable<T>>): IterableIterator<T[]>
+export declare function zip<T> (...iterables: Array<Iterable<T>>): IterableIterator<T[]>
 
 /**
  * @deprecated Use `iterable` instead
  */
-export declare function iter<T>(iterable: Iterable<T>): IterableIterator<T>;
+export declare function iter<T> (iterable: Iterable<T>): IterableIterator<T>
 
 // Async
-export declare function asyncBatch<T>(n: number): (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<T>;
-export declare function asyncBatch<T>(n: number, iterable: AsyncIterableLike<T>): AsyncIterableIterator<T>;
+export declare function asyncBatch<T> (n: number): (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<T>
+export declare function asyncBatch<T> (n: number, iterable: AsyncIterableLike<T>): AsyncIterableIterator<T>
 
-export declare function asyncChain<T>(...iterables: Array<AsyncIterableLike<T>>): AsyncIterableIterator<T>;
-export declare function asyncConcat<T>(...iterables: Array<AsyncIterableLike<T>>): AsyncIterableIterator<T>;
+export declare function asyncChain<T> (...iterables: Array<AsyncIterableLike<T>>): AsyncIterableIterator<T>
+export declare function asyncConcat<T> (...iterables: Array<AsyncIterableLike<T>>): AsyncIterableIterator<T>
 
-export declare function asyncConsume<T>(func: (item: T) => void): (iterable: AsyncIterableLike<T>) => void;
-export declare function asyncConsume<T>(func: (item: T) => void, iterable: AsyncIterableLike<T>): void;
+export declare function asyncConsume<T> (func: (item: T) => void): (iterable: AsyncIterableLike<T>) => void
+export declare function asyncConsume<T> (func: (item: T) => void, iterable: AsyncIterableLike<T>): void
 
-export declare function asyncCompress<T>(
+export declare function asyncCompress<T> (
     iterable: AsyncIterableLike<T>,
-    compress: AsyncIterableLike<boolean>,
-): AsyncIterableIterator<T>;
+    compress: AsyncIterableLike<boolean>
+): AsyncIterableIterator<T>
 
-export declare function asyncCycle<T>(iterable: AsyncIterableLike<T>): AsyncIterableIterator<T>;
+export declare function asyncCycle<T> (iterable: AsyncIterableLike<T>): AsyncIterableIterator<T>
 
-export declare function asyncDropWhile<T>(func: (item: T) => boolean):
-    (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<T>;
-export declare function asyncDropWhile<T>(func: (item: T) => boolean, iterable: AsyncIterableLike<T>):
-    AsyncIterableIterator<T>;
+export declare function asyncDropWhile<T> (func: (item: T) => boolean):
+    (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<T>
+export declare function asyncDropWhile<T> (func: (item: T) => boolean, iterable: AsyncIterableLike<T>):
+    AsyncIterableIterator<T>
 
-export declare function asyncEnumerate<T>(iterable: AsyncIterableLike<T>, start?: number):
-    AsyncIterableIterator<[number, T]>;
+export declare function asyncEnumerate<T> (iterable: AsyncIterableLike<T>, start?: number):
+    AsyncIterableIterator<[number, T]>
 
-export declare function asyncEvery<T>(func: (item: T) => boolean): (iterable: AsyncIterableLike<T>) => boolean;
-export declare function asyncEvery<T>(func: (item: T) => boolean, iterable: AsyncIterableLike<T>): boolean;
+export declare function asyncEvery<T> (func: (item: T) => boolean): (iterable: AsyncIterableLike<T>) => boolean
+export declare function asyncEvery<T> (func: (item: T) => boolean, iterable: AsyncIterableLike<T>): boolean
 
-export declare function asyncExecute<T, Args extends any[] = any[]>(
+export declare function asyncExecute<T, Args extends any[] = any[]> (
   func: (...args: Args) => Promise<T>,
   ...args: Args
-): AsyncIterableIterator<T>;
+): AsyncIterableIterator<T>
 
-export declare function asyncFilter<T>(func: (item: T) => boolean):
-    (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<T>;
-export declare function asyncFilter<T>(func: (item: T) => boolean, iterable: AsyncIterableLike<T>):
-    AsyncIterableIterator<T>;
+export declare function asyncFilter<T> (func: (item: T) => boolean):
+    (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<T>
+export declare function asyncFilter<T> (func: (item: T) => boolean, iterable: AsyncIterableLike<T>):
+    AsyncIterableIterator<T>
 
-export declare function asyncFind<T>(func: (item: T) => boolean): (iterable: AsyncIterableLike<T>) => T | null;
-export declare function asyncFind<T>(func: (item: T) => boolean, iterable: AsyncIterableLike<T>): T | null;
+export declare function asyncFind<T> (func: (item: T) => boolean): (iterable: AsyncIterableLike<T>) => T | null
+export declare function asyncFind<T> (func: (item: T) => boolean, iterable: AsyncIterableLike<T>): T | null
 
-export declare function asyncFirst<T>(iterable: AsyncIterableLike<T>): T | undefined;
+export declare function asyncFirst<T> (iterable: AsyncIterableLike<T>): T | undefined
 
-export declare function asyncFlatMap<T, O>(func: (item: T) => AsyncIterableLike<O>):
-    (iter: AsyncIterableLike<T>) => AsyncIterableIterator<O>;
-export declare function asyncFlatMap<T, O>(func: (item: T) => AsyncIterableLike<O>, iter: AsyncIterableLike<T>):
-    AsyncIterableIterator<O>;
+export declare function asyncFlatMap<T, O> (func: (item: T) => AsyncIterableLike<O>):
+    (iter: AsyncIterableLike<T>) => AsyncIterableIterator<O>
+export declare function asyncFlatMap<T, O> (func: (item: T) => AsyncIterableLike<O>, iter: AsyncIterableLike<T>):
+    AsyncIterableIterator<O>
 
-export declare function asyncGroupBy(key: null):
-  <T>(iterable: AsyncIterableLike<T>) => AsyncIterableIterator<[T, AsyncIterableIterator<T>]>;
-export declare function asyncGroupBy<T>(
+export declare function asyncGroupBy (key: null):
+  <T>(iterable: AsyncIterableLike<T>) => AsyncIterableIterator<[T, AsyncIterableIterator<T>]>
+export declare function asyncGroupBy<T> (
   key: null,
   iterable: AsyncIterableLike<T>
-): AsyncIterableIterator<[T, AsyncIterableIterator<T>]>;
-export declare function asyncGroupBy<T, K>(key: (item: T) => K):
-  (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<[K, AsyncIterableIterator<T>]>;
-export declare function asyncGroupBy<T, K>(key: (item: T) => K, iterable: AsyncIterableLike<T>):
-  AsyncIterableIterator<[K, AsyncIterableIterator<T>]>;
+): AsyncIterableIterator<[T, AsyncIterableIterator<T>]>
+export declare function asyncGroupBy<T, K> (key: (item: T) => K):
+  (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<[K, AsyncIterableIterator<T>]>
+export declare function asyncGroupBy<T, K> (key: (item: T) => K, iterable: AsyncIterableLike<T>):
+  AsyncIterableIterator<[K, AsyncIterableIterator<T>]>
 
-export declare function asyncIterable<T>(
+export declare function asyncIterable<T> (
   asyncIterator: { next: () => Promise<{value: T}> } | AsyncIterableLike<T>
-): AsyncIterableIterator<T>;
+): AsyncIterableIterator<T>
 
-export declare function asyncMap<T, O>(func: (item: T) => O): (iter: AsyncIterableLike<T>) => AsyncIterableIterator<O>;
-export declare function asyncMap<T, O>(func: (item: T) => O, iter: AsyncIterableLike<T>): AsyncIterableIterator<O>;
+export declare function asyncMap<T, O> (func: (item: T) => O): (iter: AsyncIterableLike<T>) => AsyncIterableIterator<O>
+export declare function asyncMap<T, O> (func: (item: T) => O, iter: AsyncIterableLike<T>): AsyncIterableIterator<O>
 
-export declare function asyncReduce<T, O>(func: (acc: O, item: T, c: number) => O):
-    (iterable: AsyncIterableLike<T>) => O;
-export declare function asyncReduce<T, O>(initial: O, func: (acc: O, item: T, c: number) => O):
-    (iterable: AsyncIterableLike<T>) => O;
-export declare function asyncReduce<T, O>(func: (acc: O, item: T, c: number) => O, iterable: AsyncIterableLike<T>): O;
-export declare function asyncReduce<T, O>(
+export declare function asyncReduce<T, O> (func: (acc: O, item: T, c: number) => O):
+    (iterable: AsyncIterableLike<T>) => O
+export declare function asyncReduce<T, O> (initial: O, func: (acc: O, item: T, c: number) => O):
+    (iterable: AsyncIterableLike<T>) => O
+export declare function asyncReduce<T, O> (func: (acc: O, item: T, c: number) => O, iterable: AsyncIterableLike<T>): O
+export declare function asyncReduce<T, O> (
     initial: O,
     func: (acc: O, item: T, c: number) => O,
-    iterable: AsyncIterableLike<T>,
-): O;
+    iterable: AsyncIterableLike<T>
+): O
 
-export declare function asyncSize(iterable: AsyncIterable<any>): number;
+export declare function asyncSize (iterable: AsyncIterable<any>): number
 
-export declare function asyncSlice<T>(
+export declare function asyncSlice<T> (
     opts: number | { start: number, end?: number, step?: number },
-    iterable: AsyncIterableLike<T>,
-): AsyncIterableIterator<number>;
+    iterable: AsyncIterableLike<T>
+): AsyncIterableIterator<number>
 
-export declare function asyncTakeWhile<T>(func: (item: T) => boolean):
-    (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<T>;
-export declare function asyncTakeWhile<T>(func: (item: T) => boolean, iterable: AsyncIterableLike<T>):
-    AsyncIterableIterator<T>;
+export declare function asyncTakeWhile<T> (func: (item: T) => boolean):
+    (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<T>
+export declare function asyncTakeWhile<T> (func: (item: T) => boolean, iterable: AsyncIterableLike<T>):
+    AsyncIterableIterator<T>
 
-export declare function asyncTap<T>(func: (item: T, c: number) => any, iterable: AsyncIterableLike<T>):
-    AsyncIterableIterator<T>;
+export declare function asyncTap<T> (func: (item: T, c: number) => any, iterable: AsyncIterableLike<T>):
+    AsyncIterableIterator<T>
 
-export declare function asyncTakeSorted<T>(n: number, func?: (item: T) => boolean):
-    (iterable: AsyncIterableLike<T>) => AsyncIterableLike<T>;
-export declare function asyncTakeSorted<T>(n: number, func?: (item: T) => boolean, iterable?: AsyncIterableLike<T>):
-    AsyncIterableLike<T>;
+export declare function asyncTakeSorted<T> (n: number, func?: (item: T) => boolean):
+    (iterable: AsyncIterableLike<T>) => AsyncIterableLike<T>
+export declare function asyncTakeSorted<T> (n: number, func?: (item: T) => boolean, iterable?: AsyncIterableLike<T>):
+    AsyncIterableLike<T>
 
-export declare function asyncTee<T>(iterable: AsyncIterableLike<T>, n?: number): Array<AsyncIterableIterator<T>>;
+export declare function asyncTee<T> (iterable: AsyncIterableLike<T>, n?: number): Array<AsyncIterableIterator<T>>
 
-export declare function asyncToArray<T>(iterable: AsyncIterableLike<T>): T[];
+export declare function asyncToArray<T> (iterable: AsyncIterableLike<T>): T[]
 
-export declare function asyncZipLongest<T>(...iterables: Array<AsyncIterableLike<T>>): AsyncIterableIterator<T[]>;
-export declare function asyncZipAll<T>(...iterables: Array<AsyncIterableLike<T>>): AsyncIterableIterator<T[]>;
+export declare function asyncZipLongest<T> (...iterables: Array<AsyncIterableLike<T>>): AsyncIterableIterator<T[]>
+export declare function asyncZipAll<T> (...iterables: Array<AsyncIterableLike<T>>): AsyncIterableIterator<T[]>
 
-export declare function asyncZip<T>(...iterables: Array<AsyncIterableLike<T>>): AsyncIterableIterator<T[]>;
+export declare function asyncZip<T> (...iterables: Array<AsyncIterableLike<T>>): AsyncIterableIterator<T[]>
 
-export declare function asyncRegexpSplitIter(re: RegExp):
-    (iterable: AsyncIterableLike<string>) => AsyncIterableLike<string>;
-export declare function asyncRegexpSplitIter(re: RegExp, iterable: AsyncIterableLike<string>):
-    AsyncIterableLike<string>;
+export declare function asyncRegexpSplitIter (re: RegExp):
+    (iterable: AsyncIterableLike<string>) => AsyncIterableLike<string>
+export declare function asyncRegexpSplitIter (re: RegExp, iterable: AsyncIterableLike<string>):
+    AsyncIterableLike<string>
 
-export declare function asyncRegexpExecIter(re: RegExp):
-    (iterable: AsyncIterableLike<string>) => AsyncIterableLike<string>;
-export declare function asyncRegexpExecIter(re: RegExp, iterable: AsyncIterableLike<string>):
-    AsyncIterableLike<string>;
+export declare function asyncRegexpExecIter (re: RegExp):
+    (iterable: AsyncIterableLike<string>) => AsyncIterableLike<string>
+export declare function asyncRegexpExecIter (re: RegExp, iterable: AsyncIterableLike<string>):
+    AsyncIterableLike<string>
 
-export declare function asyncSplitLines(iterable: AsyncIterableLike<string>): AsyncIterableLike<string>;
+export declare function asyncSplitLines (iterable: AsyncIterableLike<string>): AsyncIterableLike<string>
 
-export declare function asyncSome<T>(func: (item: T) => boolean): (iterable: AsyncIterableLike<T>) => boolean;
-export declare function asyncSome<T>(func: (item: T) => boolean, iterable: AsyncIterableLike<T>): boolean;
+export declare function asyncSome<T> (func: (item: T) => boolean): (iterable: AsyncIterableLike<T>) => boolean
+export declare function asyncSome<T> (func: (item: T) => boolean, iterable: AsyncIterableLike<T>): boolean
 
-export declare function asyncBuffer<T>(n: number): (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<T>;
-export declare function asyncBuffer<T>(n: number, iterable: AsyncIterableLike<T>): AsyncIterableIterator<T>;
+export declare function asyncBuffer<T> (n: number): (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<T>
+export declare function asyncBuffer<T> (n: number, iterable: AsyncIterableLike<T>): AsyncIterableIterator<T>
 
-export declare function asyncThrottle<T>(n: number): (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<T>;
-export declare function asyncThrottle<T>(n: number, iterable: AsyncIterableLike<T>): AsyncIterableIterator<T>;
+export declare function asyncThrottle<T> (n: number): (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<T>
+export declare function asyncThrottle<T> (n: number, iterable: AsyncIterableLike<T>): AsyncIterableIterator<T>
 
 /**
  * @deprecated Use `asyncIterable` instead
  */
-export declare function asyncIter<T>(syncIterable: AsyncIterableLike<T>): AsyncIterableIterator<T>;
+export declare function asyncIter<T> (syncIterable: AsyncIterableLike<T>): AsyncIterableIterator<T>

--- a/src/iter.d.ts
+++ b/src/iter.d.ts
@@ -1,2 +1,2 @@
-import { iter } from "./index";
-export = iter;
+import { iter } from './index'
+export = iter

--- a/src/iterable.d.ts
+++ b/src/iterable.d.ts
@@ -1,2 +1,2 @@
-import { iterable } from "./index";
-export = iterable;
+import { iterable } from './index'
+export = iterable

--- a/src/keys.d.ts
+++ b/src/keys.d.ts
@@ -1,2 +1,2 @@
-import { keys } from "./index";
-export = keys;
+import { keys } from './index'
+export = keys

--- a/src/map.d.ts
+++ b/src/map.d.ts
@@ -1,2 +1,2 @@
-import { map } from "./index";
-export = map;
+import { map } from './index'
+export = map

--- a/src/permutations.d.ts
+++ b/src/permutations.d.ts
@@ -1,2 +1,2 @@
-import { permutations } from "./index";
-export = permutations;
+import { permutations } from './index'
+export = permutations

--- a/src/product.d.ts
+++ b/src/product.d.ts
@@ -1,2 +1,2 @@
-import { product } from "./index";
-export = product;
+import { product } from './index'
+export = product

--- a/src/range.d.ts
+++ b/src/range.d.ts
@@ -1,2 +1,2 @@
-import { range } from "./index";
-export = range;
+import { range } from './index'
+export = range

--- a/src/reduce.d.ts
+++ b/src/reduce.d.ts
@@ -1,2 +1,2 @@
-import { reduce } from "./index";
-export = reduce;
+import { reduce } from './index'
+export = reduce

--- a/src/regexp-exec-iter.d.ts
+++ b/src/regexp-exec-iter.d.ts
@@ -1,2 +1,2 @@
-import { regexpExecIter } from "./index";
-export = regexpExecIter;
+import { regexpExecIter } from './index'
+export = regexpExecIter

--- a/src/regexp-exec.d.ts
+++ b/src/regexp-exec.d.ts
@@ -1,2 +1,2 @@
-import { regexpExec } from "./index";
-export = regexpExec;
+import { regexpExec } from './index'
+export = regexpExec

--- a/src/regexp-split-iter.d.ts
+++ b/src/regexp-split-iter.d.ts
@@ -1,2 +1,2 @@
-import { regexpSplitIter } from "./index";
-export = regexpSplitIter;
+import { regexpSplitIter } from './index'
+export = regexpSplitIter

--- a/src/regexp-split.d.ts
+++ b/src/regexp-split.d.ts
@@ -1,2 +1,2 @@
-import { regexpSplit } from "./index";
-export = regexpSplit;
+import { regexpSplit } from './index'
+export = regexpSplit

--- a/src/repeat.d.ts
+++ b/src/repeat.d.ts
@@ -1,2 +1,2 @@
-import { repeat } from "./index";
-export = repeat;
+import { repeat } from './index'
+export = repeat

--- a/src/size.d.ts
+++ b/src/size.d.ts
@@ -1,2 +1,2 @@
-import { size } from "./index";
-export = size;
+import { size } from './index'
+export = size

--- a/src/slice.d.ts
+++ b/src/slice.d.ts
@@ -1,2 +1,2 @@
-import { slice } from "./index";
-export = slice;
+import { slice } from './index'
+export = slice

--- a/src/some.d.ts
+++ b/src/some.d.ts
@@ -1,2 +1,2 @@
-import { some } from "./index";
-export = some;
+import { some } from './index'
+export = some

--- a/src/split-lines.d.ts
+++ b/src/split-lines.d.ts
@@ -1,2 +1,2 @@
-import { splitLines } from "./index";
-export = splitLines;
+import { splitLines } from './index'
+export = splitLines

--- a/src/take-sorted.d.ts
+++ b/src/take-sorted.d.ts
@@ -1,2 +1,2 @@
-import { takeSorted } from "./index";
-export = takeSorted;
+import { takeSorted } from './index'
+export = takeSorted

--- a/src/take-while.d.ts
+++ b/src/take-while.d.ts
@@ -1,2 +1,2 @@
-import { takeWhile } from "./index";
-export = takeWhile;
+import { takeWhile } from './index'
+export = takeWhile

--- a/src/tap.d.ts
+++ b/src/tap.d.ts
@@ -1,2 +1,2 @@
-import { tap } from "./index";
-export = tap;
+import { tap } from './index'
+export = tap

--- a/src/tee.d.ts
+++ b/src/tee.d.ts
@@ -1,2 +1,2 @@
-import { tee } from "./index";
-export = tee;
+import { tee } from './index'
+export = tee

--- a/src/to-array.d.ts
+++ b/src/to-array.d.ts
@@ -1,2 +1,2 @@
-import { toArray } from "./index";
-export = toArray;
+import { toArray } from './index'
+export = toArray

--- a/src/values.d.ts
+++ b/src/values.d.ts
@@ -1,2 +1,2 @@
-import { values } from "./index";
-export = values;
+import { values } from './index'
+export = values

--- a/src/zip-all.d.ts
+++ b/src/zip-all.d.ts
@@ -1,2 +1,2 @@
-import { zipAll } from "./index";
-export = zipAll;
+import { zipAll } from './index'
+export = zipAll

--- a/src/zip-longest.d.ts
+++ b/src/zip-longest.d.ts
@@ -1,2 +1,2 @@
-import { zipLongest } from "./index";
-export = zipLongest;
+import { zipLongest } from './index'
+export = zipLongest

--- a/src/zip.d.ts
+++ b/src/zip.d.ts
@@ -1,2 +1,2 @@
-import { zip } from "./index";
-export = zip;
+import { zip } from './index'
+export = zip

--- a/tslint.json
+++ b/tslint.json
@@ -1,11 +1,3 @@
 {
-  "defaultSeverity": "error",
-  "extends": [
-    "tslint:recommended"
-  ],
-  "jsRules": {},
-  "rules": {
-    "trailing-comma": false
-  },
-  "rulesDirectory": []
+  "extends": "tslint-config-standard"
 }


### PR DESCRIPTION
## Pros

* To be consistent with JavaScript code: This project uses [`standard`](https://standardjs.com/) for its JS code and [`tslint-config-standard`](https://github.com/blakeembrey/tslint-config-standard) mimics standard's style.

* Some of `tslint:recommended` rules make no sense (such as `trailing-comma`).

## Cons

* Other contributors might have to change their coding habits.

---

What do you think, @conartist6?