### PR TITLE
fixed babel config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,7 @@
   "env": {
     "es5": {
       "plugins": [
-        ["@babel/plugin-transform-runtime", {"useESModules": true}]
+        ["@babel/plugin-transform-runtime", {"useESModules": true, "corejs": 2}]
       ],
       "presets": [
         ["@babel/preset-env", {
@@ -12,13 +12,12 @@
     },
     "es2015": {
       "plugins": [
-        ["@babel/plugin-transform-runtime", {"useESModules": true}],
         "@babel/plugin-proposal-async-generator-functions"
       ]
     },
     "es5-cjs": {
       "plugins": [
-        "@babel/plugin-transform-runtime",
+        ["@babel/plugin-transform-runtime", {"corejs": 2}],
         "add-module-exports"
       ],
       "presets": [
@@ -29,7 +28,6 @@
       "plugins": [
         "add-module-exports",
         "@babel/plugin-transform-modules-commonjs",
-        "@babel/plugin-transform-runtime",
         "@babel/plugin-proposal-async-generator-functions"
       ]
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -729,6 +729,15 @@
         "regenerator-runtime": "^0.12.0"
       }
     },
+    "@babel/runtime-corejs2": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.1.5.tgz",
+      "integrity": "sha512-WsYRwQsFhVmxkAqwypPTZyV9GpkqMEaAr2zOItOmqSX2GBFaI+eq98CN81e13o0zaUKJOQGYyjhNVqj56nnkYg==",
+      "requires": {
+        "core-js": "^2.5.7",
+        "regenerator-runtime": "^0.12.0"
+      }
+    },
     "@babel/template": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
@@ -1917,8 +1926,7 @@
     "core-js": {
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-      "dev": true
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
+    "@babel/runtime-corejs2": "^7.1.5",
     "dequeue": "^1.0.5",
     "little-ds-toolkit": "^1.1.0",
     "typescript-tuple": "^1.4.0",


### PR DESCRIPTION
This alternative fix, uses the "corejs: 2" option of .babelrc