### PR TITLE
Refactoring: TypeScript definition of merge(), asyncMerge() and their helpers

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -113,6 +113,34 @@ type AsyncFlatReturn<
   AsyncIterableElement<Iter>
 >>
 
+/**
+ * Functions of type `MergePickFunc` is
+ * to be used as `pickFunc` parameter of `merge()`.
+ *
+ * This function decides what sequence to use.
+ *
+ * @param items An array of iterators corresponding to respective iterables passed to `merge()`.
+ * @return Index of chosen sequence.
+ */
+export interface MergePickFunc<Value> {
+  (items: ReadonlyArray<IteratorResult<Value> | null>): number
+}
+
+/**
+ * Functions of type `AsyncMergePickFunc` is
+ * to be used as `pickFunc` parameter of `asyncMerge()`.
+ *
+ * This function decides what sequence to use.
+ *
+ * @param items An array of iterators corresponding to respective iterables passed to `asyncMerge()`.
+ * @return Index of chosen sequence.
+ */
+export interface AsyncMergePickFunc<Value> {
+  (items: ReadonlyArray<
+    Promise<IteratorResult<Value> | null>
+  >): number
+}
+
 // Sync
 export declare function keys (obj: { [id: string]: any }): IterableIterator<string>
 export declare function values<T> (obj: { [id: string]: T }): IterableIterator<T>
@@ -243,8 +271,8 @@ export declare function iterable<T> (iterator: { next: () => {value: T} } | Iter
 export declare function map<T, O> (func: (item: T) => O): (iter: Iterable<T>) => IterableIterator<O>
 export declare function map<T, O> (func: (item: T) => O, iter: Iterable<T>): IterableIterator<O>
 
-export declare function merge<T> (pickFunc: (items: ReadonlyArray<{ readonly done: boolean, readonly value: T } | { readonly done: boolean } | null>) => number): (iterables: ReadonlyArray<Iterable<T>>) => IterableIterator<T>
-export declare function merge<T> (pickFunc: (items: ReadonlyArray<{ readonly done: boolean, readonly value: T } | { readonly done: boolean } | null>) => number, iterables: ReadonlyArray<Iterable<T>>): IterableIterator<T>
+export declare function merge<T> (pickFunc: MergePickFunc<T>): (iterables: ReadonlyArray<Iterable<T>>) => IterableIterator<T>
+export declare function merge<T> (pickFunc: MergePickFunc<T>, iterables: ReadonlyArray<Iterable<T>>): IterableIterator<T>
 
 export declare const permutations: CombinationsPermutations
 
@@ -435,8 +463,8 @@ export declare function asyncIterable<T> (
 export declare function asyncMap<T, O> (func: (item: T) => O): (iter: AsyncIterableLike<T>) => AsyncIterableIterator<O>
 export declare function asyncMap<T, O> (func: (item: T) => O, iter: AsyncIterableLike<T>): AsyncIterableIterator<O>
 
-export declare function asyncMerge<T> (pickFunc: (items: ReadonlyArray<Promise<{ done: boolean, value: T }> | Promise<{ done: boolean }> | null>) => boolean): (iterables: ReadonlyArray<AsyncIterableLike<T>>) => AsyncIterableIterator<T>
-export declare function asyncMerge<T> (pickFunc: (items: ReadonlyArray<Promise<{ done: boolean, value: T }> | Promise<{ done: boolean }> | null>) => boolean, iterables: ReadonlyArray<AsyncIterableLike<T>>): AsyncIterableIterator<T>
+export declare function asyncMerge<T> (pickFunc: AsyncMergePickFunc<T>): (iterables: ReadonlyArray<AsyncIterableLike<T>>) => AsyncIterableIterator<T>
+export declare function asyncMerge<T> (pickFunc: AsyncMergePickFunc<T>, iterables: ReadonlyArray<AsyncIterableLike<T>>): AsyncIterableIterator<T>
 
 export declare function asyncReduce<T, O> (func: (acc: O, item: T, c: number) => O):
     (iterable: AsyncIterableLike<T>) => O
@@ -499,25 +527,13 @@ export declare function asyncBuffer<T> (n: number, iterable: AsyncIterableLike<T
 export declare function asyncThrottle<T> (n: number): (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<T>
 export declare function asyncThrottle<T> (n: number, iterable: AsyncIterableLike<T>): AsyncIterableIterator<T>
 
-/**
- * merge helpers
- */
-
-export declare function mergeByComparison (comparator: (a: any, b: any) => number):
-  (items: ReadonlyArray<{ readonly done: boolean, readonly value: any } | { readonly done: boolean } | null>) => number
-export declare function mergeByChance (weights: Array<number>):
-  (items: ReadonlyArray<{ readonly done: boolean, readonly value: any } | { readonly done: boolean } | null>) => number
-export declare function mergeByPosition (step: number):
-  (items: ReadonlyArray<{ readonly done: boolean, readonly value: any } | { readonly done: boolean } | null>) => number
-
-export declare function asyncMergeByComparison (comparator: (a: any, b: any) => number):
-  (items: ReadonlyArray<{ readonly done: boolean, readonly value: any } | { readonly done: boolean } | null>) => number
-export declare function asyncMergeByChance (weights: Array<number>):
-  (items: ReadonlyArray<{ readonly done: boolean, readonly value: any } | { readonly done: boolean } | null>) => number
-export declare function asyncMergeByPosition (step: number):
-  (items: ReadonlyArray<{ readonly done: boolean, readonly value: any } | { readonly done: boolean } | null>) => number
-export declare function asyncMergeByReadiness (timeout: number):
-  (items: ReadonlyArray<{ readonly done: boolean, readonly value: any } | { readonly done: boolean } | null>) => number
+// merge helpers
+export declare function mergeByComparison<T> (comparator: (a: T, b: T) => number): MergePickFunc<T>
+export declare function mergeByChance (weights: ReadonlyArray<number>): MergePickFunc<any>
+export declare function mergeByPosition (step?: number): MergePickFunc<any>
+export declare function asyncMergeByComparison<T> (comparator: (a: T, b: T) => number): AsyncMergePickFunc<T>
+export declare function asyncMergeByChance (weights: ReadonlyArray<number>): AsyncMergePickFunc<any>
+export declare function asyncMergeByPosition (step?: number): AsyncMergePickFunc<any>
 
 /**
  * @deprecated Use `asyncIterable` instead


### PR DESCRIPTION
- Give `pickFunc` parameters a named typed
- Types of `pickFunc`s are exported to help TypeScript users to define their own picker
- Make `mergeByComparision` generic
- Make `step` parameter of `mergeByPosition` optional
- The "merge helpers" comment shouldn't be a doccomment

**NOTES:** This is still a work in progress, I created this pull request for discussion.