### PR TITLE
Fix return types of asyncReduce, asyncSome, asyncEvery

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ import { takeWhile } from 'iter-tools/es2018'; // ES2018
 Note: **file names are all lowercase, dash separated. Module names are camelcase.**
 
 ## Async iterators
-Async iterators are a new feature introduced by ES2018. Iter-tools implements an alternate versions of many functions that works on async iterators as well as regular iterators.
+Async iterators are a new feature introduced by ES2018. Iter-tools implements an alternate versions of many functions that works on async iterators as well as regular iterators. Note some common patterns:
+* they return either an async iterable (asyncMap, asyncFilter for example) or a promise returning a value (asyncReduce for example)
+* whenever they take a function as argument, this can return a value or a promise
 
 # Create iterators
 ## Range
@@ -240,6 +242,7 @@ map(x => x * x, range(4)); // 0, 1, 4, 9
 ```
 
 ## async-map
+The same as map but working with sync and async iterables. The first argument can be a function returning synchronously or a promise.
 ```js
 await asyncMap(animal => animal.kind, [
   Promise.resolve({type: 'cat'}),
@@ -259,7 +262,7 @@ await asyncFilter(animal => animal.kind.slice(1) === 'at', [
 ```
 
 ## async-filter
-See filter
+See filter. The first argument can be a function returning synchronously or a promise.
 
 ## take-while
 It returns values as soon as the function is true. Then it stops.
@@ -268,7 +271,7 @@ takeWhile(isEven, range(4)); // 0
 ```
 
 ## async-take-while
-Same as Take While but works on both sync and async iterables.
+Same as Take While but works on both sync and async iterables. The first argument can be a function returning synchronously or a promise.
 
 ## drop-while
 It starts returning values when the function is false. Then it keeps going until the iterable is exausted.
@@ -277,7 +280,7 @@ dropWhile(isEven, range(4)); // 1, 2, 3
 ```
 
 ## async-drop-while
-Same as Drop While but works on both sync and async iterables.
+Same as Drop While but works on both sync and async iterables. The first argument can be a function returning synchronously or a promise.
 
 ## slice
 It returns an iterable that returns a slice of an iterable.
@@ -328,7 +331,7 @@ reduce((acc, v) => acc += v, range(4)); // 6
 ```
 
 ## async-reduce
-Same as reduce but works on both sync and async iterables.
+Same as reduce but works on both sync and async iterables. The function argument can return synchronously or a promise.
 
 ## batch
 Takes a number and an iterable and returns an iterable divided into batches
@@ -550,7 +553,7 @@ groupBySquare([1, 1, 1, 1, -1, -1, -1, 4]);
 ```
 
 ## async-group-by
-Same as groupBy but works on both sync and async iterables.
+Same as groupBy but works on both sync and async iterables. The first argument can be a function returning synchronously or a promise.
 
 ## tee
 It returns 2 or more copies of an iterable. In reality they are not copies (it is not possible) they are distinct iterables sharing the original one and caching the values when one of the copy pull a new value from the original iterable.
@@ -625,7 +628,7 @@ consume((item) => console.log(item), [1, 2, 3]) // prints 1, 2, 3
 ```
 
 ## async-consume
-The equivalent of consume, for async iterables. It returns a promise.
+The equivalent of consume, for async iterables. It returns a promise. The argument can be a function returning a promise.
 
 ## first
 It returns the fist item from an iterable.
@@ -643,7 +646,7 @@ find(animal => animal.kind === 'dog', [{type: 'cat'}, {type: 'dog'}])
 ```
 
 ## async-find
-Same as find but for async iterables
+Same as find but for async iterables. The first argument can be a function returning synchronously or a promise.
 ```js
 await asyncFind(animal => animal.kind === 'dog', [
   Promise.resolve({type: 'cat'}),
@@ -661,7 +664,7 @@ compose(
 ```
 
 ## async-tap
-Same as tap, but for async iterables
+Same as tap, but for async iterables. The argument can be a function returning synchronously or a promise.
 ```js
 compose(
   asyncTap(item => console.log(item)),
@@ -689,10 +692,10 @@ some((n) => n % 2 === 0, [1, 3, 7]) // returns false
 ```
 
 ## async-some
-It returns true if running the function, at least one item returns true (can be curried).
+It returns true if running the function, at least one item returns true (can be curried). The argument can be a function returning synchronously or a promise.
 ```js
-asyncSome(asyncIter([1, 2, 3])) // returns a promise that resolve on true
-asyncSome(asyncIter([1, 3, 7])) // returns a promise that resolve on false
+asyncSome((n) => n % 2 === 0, asyncIter([1, 2, 3])) // returns a promise that resolve on true
+asyncSome((n) => n % 2 === 0, asyncIter([1, 3, 7])) // returns a promise that resolve on false
 ```
 
 ## every
@@ -703,10 +706,10 @@ every((n) => n % 2 === 0, [2, 4, 6]) // returns true
 ```
 
 ## async-every
-It returns true if running the function, all items return true (can be curried).
+It returns true if running the function, all items return true (can be curried). The argument can be a function returning synchronously or a promise.
 ```js
-asyncEvery(asyncIter([1, 2, 3])) // returns a promise that resolve on false
-asyncEvery(asyncIter([2, 4, 6])) // returns a promise that resolve on true
+asyncEvery((n) => n % 2 === 0, asyncIter([1, 2, 3])) // returns a promise that resolve on false
+asyncEvery((n) => n % 2 === 0, asyncIter([2, 4, 6])) // returns a promise that resolve on true
 ```
 
 ## async-throttle

--- a/src/__test__/consume.test.js
+++ b/src/__test__/consume.test.js
@@ -30,6 +30,15 @@ describe('asyncConsume', function () {
     expect(arr).toEqual([1, 2, 3])
   })
 
+  it('consumes an iterable using a promise', async function () {
+    const arr = []
+    await asyncConsume((item) => {
+      arr.push(item)
+      return Promise.resolve(0)
+    }, [1, 2, 3])
+    expect(arr).toEqual([1, 2, 3])
+  })
+
   it('consumes an iterable (curried)', async function () {
     const arr = []
     const consumePush = asyncConsume((item) => arr.push(item))

--- a/src/__test__/drop-while.test.js
+++ b/src/__test__/drop-while.test.js
@@ -33,6 +33,11 @@ describe('asyncDropWhile', function () {
     expect(await asyncToArray(iter)).toEqual([4, 5, 6])
   })
 
+  it('dropWhile on iterable (using a promise)', async function () {
+    const iter = asyncDropWhile((item) => Promise.resolve(item !== 4), range({ start: 1, end: 7 }))
+    expect(await asyncToArray(iter)).toEqual([4, 5, 6])
+  })
+
   it('dropWhile on iterable (curried version)', async function () {
     const iter = asyncDropWhile((item) => item !== 4)
     expect(await asyncToArray(iter(range({ start: 1, end: 7 })))).toEqual([4, 5, 6])

--- a/src/__test__/every.test.js
+++ b/src/__test__/every.test.js
@@ -20,6 +20,10 @@ describe('asyncEvery', function () {
     expect(await asyncEvery((n) => n % 2 === 0, asyncIterable([4, 2, 6, 4, 8, 6]))).toBe(true)
   })
 
+  it('returns true if at least one item is true (using a promise)', async function () {
+    expect(await asyncEvery((n) => Promise.resolve(n % 2 === 0), asyncIterable([4, 2, 6, 4, 8, 6]))).toBe(true)
+  })
+
   it('returns false if all items are false', async function () {
     expect(await asyncEvery((n) => n % 2 === 0, asyncIterable([4, 1, 6, 4, 8, 6]))).toBe(false)
   })

--- a/src/__test__/filter.test.js
+++ b/src/__test__/filter.test.js
@@ -28,6 +28,11 @@ describe('asyncFilter', function () {
     expect(await asyncToArray(iter)).toEqual([2, 4, 6])
   })
 
+  it('returns filtered iterable (using a promise)', async function () {
+    const iter = asyncFilter(function (item) { return Promise.resolve(item % 2 === 0) }, [1, 2, 3, 4, 5, 6])
+    expect(await asyncToArray(iter)).toEqual([2, 4, 6])
+  })
+
   it('returns filtered iterable from iterable', async function () {
     const iter = asyncFilter(function (item) { return item % 2 === 0 }, range({ start: 1, end: 7 }))
     expect(await asyncToArray(iter)).toEqual([2, 4, 6])

--- a/src/__test__/find.test.js
+++ b/src/__test__/find.test.js
@@ -39,6 +39,11 @@ describe('asyncFind', function () {
     expect(await found).toBe(5)
   })
 
+  it('returns found item (using a promise)', async function () {
+    const found = asyncFind(async (item) => item === 5, [1, 2, 3, 4, 5, 6])
+    expect(await found).toBe(5)
+  })
+
   it('returns null if no item found', async function () {
     const found = asyncFind((item) => item === 100, [1, 2, 3, 4, 5, 6])
     expect(await found).toBe(null)

--- a/src/__test__/flat.test.js
+++ b/src/__test__/flat.test.js
@@ -93,4 +93,9 @@ describe('asyncFlat', function () {
     const iter = asyncFlat((depth, iter) => !(typeof iter === 'string' && iter.length === 1), [['a', 'b'], ['c', ['d', 'e']], [['fghi']]])
     expect(await asyncToArray(iter)).toEqual(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'])
   })
+
+  it('flats using custom function (using a promise)', async function () {
+    const iter = asyncFlat(async (depth, iter) => !(typeof iter === 'string' && iter.length === 1), [['a', 'b'], ['c', ['d', 'e']], [['fghi']]])
+    expect(await asyncToArray(iter)).toEqual(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'])
+  })
 })

--- a/src/__test__/group-by.test.js
+++ b/src/__test__/group-by.test.js
@@ -19,6 +19,23 @@ describe('groupBy', function () {
     expect(next.done).toBe(true)
   })
 
+  it('groupBy use key function', function () {
+    const iter = groupBy((item) => item.toLowerCase(), 'AaaBbaACccCD')
+    let next
+    next = iter.next()
+    expect(next.value[0]).toBe('a')
+    next = iter.next()
+    expect(next.value[0]).toBe('b')
+    next = iter.next()
+    expect(next.value[0]).toBe('a')
+    next = iter.next()
+    expect(next.value[0]).toBe('c')
+    next = iter.next()
+    expect(next.value[0]).toBe('d')
+    next = iter.next()
+    expect(next.done).toBe(true)
+  })
+
   it('groupBy main cursor (curried)', function () {
     const iter = groupBy(null)('AAABBAACCCCD')
     let next
@@ -91,6 +108,40 @@ describe('asyncGroupBy', function () {
     expect(next.value[0]).toBe('C')
     next = await iter.next()
     expect(next.value[0]).toBe('D')
+    next = await iter.next()
+    expect(next.done).toBe(true)
+  })
+
+  it('groupBy use key function', async function () {
+    const iter = asyncGroupBy((item) => item.toLowerCase(), 'AaaBbaACccCD')
+    let next
+    next = await iter.next()
+    expect(next.value[0]).toBe('a')
+    next = await iter.next()
+    expect(next.value[0]).toBe('b')
+    next = await iter.next()
+    expect(next.value[0]).toBe('a')
+    next = await iter.next()
+    expect(next.value[0]).toBe('c')
+    next = await iter.next()
+    expect(next.value[0]).toBe('d')
+    next = await iter.next()
+    expect(next.done).toBe(true)
+  })
+
+  it('groupBy use key function (using a promise)', async function () {
+    const iter = asyncGroupBy(async (item) => item.toLowerCase(), 'AaaBbaACccCD')
+    let next
+    next = await iter.next()
+    expect(next.value[0]).toBe('a')
+    next = await iter.next()
+    expect(next.value[0]).toBe('b')
+    next = await iter.next()
+    expect(next.value[0]).toBe('a')
+    next = await iter.next()
+    expect(next.value[0]).toBe('c')
+    next = await iter.next()
+    expect(next.value[0]).toBe('d')
     next = await iter.next()
     expect(next.done).toBe(true)
   })

--- a/src/__test__/map.test.js
+++ b/src/__test__/map.test.js
@@ -28,6 +28,11 @@ describe('asyncMap', function () {
     expect(await asyncToArray(iter)).toEqual([2, 4, 6])
   })
 
+  it('returns mapped iterable (using a promise)', async function () {
+    const iter = asyncMap((item) => Promise.resolve(item * 2), [1, 2, 3])
+    expect(await asyncToArray(iter)).toEqual([2, 4, 6])
+  })
+
   it('returns mapped iterable from iterable', async function () {
     const iter = asyncMap((item) => item * 2, range({ start: 1, end: 4 }))
     expect(await asyncToArray(iter)).toEqual([2, 4, 6])

--- a/src/__test__/reduce.test.js
+++ b/src/__test__/reduce.test.js
@@ -45,6 +45,11 @@ describe('asyncReduce', function () {
     expect(sum).toBe(6)
   })
 
+  it('sums an array (using a promise)', async function () {
+    const sum = await asyncReduce(async (acc = 0, x) => acc + x, [0, 1, 2, 3])
+    expect(sum).toBe(6)
+  })
+
   it('sums a range', async function () {
     const sum = await asyncReduce((acc = 0, x) => acc + x, asyncIterable(range(4)))
     expect(sum).toBe(6)

--- a/src/__test__/some.test.js
+++ b/src/__test__/some.test.js
@@ -20,6 +20,10 @@ describe('asyncSome', function () {
     expect(await asyncSome((n) => n % 2 === 0, asyncIterable([1, 2, 3, 4, 5, 6]))).toBe(true)
   })
 
+  it('returns true if at least one item is true (using a promise)', async function () {
+    expect(await asyncSome((n) => Promise.resolve(n % 2 === 0), asyncIterable([1, 2, 3, 4, 5, 6]))).toBe(true)
+  })
+
   it('returns false if all items are false', async function () {
     expect(await asyncSome((n) => n % 2 === 0, asyncIterable([1, 3, 3, 7, 5, 1]))).toBe(false)
   })

--- a/src/__test__/take-while.test.js
+++ b/src/__test__/take-while.test.js
@@ -28,6 +28,11 @@ describe('asyncTakeWhile', function () {
     expect(await asyncToArray(iter)).toEqual([2, 2])
   })
 
+  it('takeWhile on array (using a promise)', async function () {
+    const iter = asyncTakeWhile((item) => Promise.resolve(item % 2 === 0), [2, 2, 3, 2, 2, 2])
+    expect(await asyncToArray(iter)).toEqual([2, 2])
+  })
+
   it('takeWhile on iterable', async function () {
     const iter = asyncTakeWhile((item) => item !== 4, range({ start: 1, end: 7 }))
     expect(await asyncToArray(iter)).toEqual([1, 2, 3])

--- a/src/__test__/tap.test.js
+++ b/src/__test__/tap.test.js
@@ -24,6 +24,11 @@ describe('asyncTap', function () {
     expect(await asyncToArray(iter)).toEqual([1, 2, 3])
   })
 
+  it('return tapped iterable (using a promise)', async function () {
+    const iter = asyncTap(function (item) { return Promise.resolve(item * 2) }, [1, 2, 3])
+    expect(await asyncToArray(iter)).toEqual([1, 2, 3])
+  })
+
   it('return tapped iterable from iterable', async function () {
     const iter = asyncTap(function (item) { return item * 2 }, range({ start: 1, end: 4 }))
     expect(await asyncToArray(iter)).toEqual([1, 2, 3])

--- a/src/async-consume.mjs
+++ b/src/async-consume.mjs
@@ -2,7 +2,7 @@ import ensureAsyncIterable from './internal/ensure-async-iterable'
 
 async function consume (func, iterable) {
   for await (const item of ensureAsyncIterable(iterable)) {
-    func(item)
+    await func(item)
   }
 }
 

--- a/src/async-drop-while.mjs
+++ b/src/async-drop-while.mjs
@@ -7,7 +7,7 @@ async function * dropWhile (func, iterable) {
     if (!drop) {
       yield item
     } else {
-      drop = func(item, c++)
+      drop = await func(item, c++)
       if (!drop) {
         yield item
       }

--- a/src/async-every.mjs
+++ b/src/async-every.mjs
@@ -3,7 +3,7 @@ import ensureAsyncIterable from './internal/ensure-async-iterable'
 async function every (func, iterable) {
   let c = 0
   for await (const item of ensureAsyncIterable(iterable)) {
-    if (!func(item, c++)) {
+    if (!(await func(item, c++))) {
       return false
     }
   }

--- a/src/async-filter.mjs
+++ b/src/async-filter.mjs
@@ -3,7 +3,7 @@ import ensureAsyncIterable from './internal/ensure-async-iterable'
 async function * filter (func, iterable) {
   let c = 0
   for await (const item of ensureAsyncIterable(iterable)) {
-    if (func(item, c++)) {
+    if ((await func(item, c++))) {
       yield item
     }
   }

--- a/src/async-find.mjs
+++ b/src/async-find.mjs
@@ -3,7 +3,7 @@ import ensureAsyncIterable from './internal/ensure-async-iterable'
 async function find (func, iterable) {
   let c = 0
   for await (const item of ensureAsyncIterable(iterable)) {
-    if (func(item, c++)) {
+    if ((await func(item, c++))) {
       return item
     }
   }

--- a/src/async-flat.mjs
+++ b/src/async-flat.mjs
@@ -15,7 +15,7 @@ const defaultShouldIFlat = (depth) => {
 
 function asyncFlat (shouldIFlat, iterable) {
   async function * _asyncFlat (currentDepth, iterable) {
-    if (shouldIFlat(currentDepth, iterable)) {
+    if ((await shouldIFlat(currentDepth, iterable))) {
       for await (const iter of iterable) {
         yield * _asyncFlat(currentDepth + 1, iter)
       }

--- a/src/async-group-by.mjs
+++ b/src/async-group-by.mjs
@@ -12,7 +12,7 @@ async function * groupBy (selector, iterable) {
       yield currentItem.value
       currentItem = await iterator.next()
       if (currentItem.done) return
-      currentKey = selector(currentItem.value)
+      currentKey = await selector(currentItem.value)
       if (previousKey !== currentKey) {
         return
       }
@@ -24,7 +24,7 @@ async function * groupBy (selector, iterable) {
 
     while (true) {
       if (currentItem.done) return
-      currentKey = selector(currentItem.value)
+      currentKey = await selector(currentItem.value)
       if (previousKey !== currentKey) {
         previousKey = currentKey
         yield [currentKey, group()]

--- a/src/async-map.mjs
+++ b/src/async-map.mjs
@@ -3,7 +3,7 @@ import ensureAsyncIterable from './internal/ensure-async-iterable'
 async function * map (func, iterable) {
   let c = 0
   for await (const item of ensureAsyncIterable(iterable)) {
-    yield func(item, c++)
+    yield (await func(item, c++))
   }
 }
 

--- a/src/async-reduce.mjs
+++ b/src/async-reduce.mjs
@@ -15,7 +15,7 @@ async function reduce (initial, func, iterable) {
     }
     let result
     while (!(result = await iterator.next()).done) {
-      acc = func(acc, result.value, c++)
+      acc = await func(acc, result.value, c++)
     }
     return acc
   } finally { // close the iterable in case of exceptions

--- a/src/async-some.mjs
+++ b/src/async-some.mjs
@@ -3,7 +3,7 @@ import ensureAsyncIterable from './internal/ensure-async-iterable'
 async function some (func, iterable) {
   let c = 0
   for await (const item of ensureAsyncIterable(iterable)) {
-    if (func(item, c++)) {
+    if ((await func(item, c++))) {
       return true
     }
   }

--- a/src/async-take-while.mjs
+++ b/src/async-take-while.mjs
@@ -4,7 +4,7 @@ async function * takeWhile (func, iterable) {
   let take = true
   let c = 0
   for await (const item of ensureAsyncIterable(iterable)) {
-    take = func(item, c++)
+    take = await func(item, c++)
     if (take) {
       yield item
     } else {

--- a/src/async-tap.mjs
+++ b/src/async-tap.mjs
@@ -3,7 +3,7 @@ import ensureAsyncIterable from './internal/ensure-async-iterable'
 async function * tap (func, iterable) {
   let c = 0
   for await (const item of ensureAsyncIterable(iterable)) {
-    func(item, c++)
+    await func(item, c++)
     yield item
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -9,6 +9,7 @@ type AsyncIterableLike<T> = AsyncIterable<T> | Iterable<T>
 type ReasonableNumber = UnionRange<32>
 type IterableElement<Iter> = Iter extends Iterable<infer X> ? X : never
 type AsyncIterableElement<Iter> = Iter extends AsyncIterableLike<infer X> ? X : never
+type MaybePromise<T> = T | Promise<T>
 
 /**
  * Function signature of `permutations` and `combinations`
@@ -350,8 +351,8 @@ export declare function asyncBatch<T> (n: number, iterable: AsyncIterableLike<T>
 export declare function asyncChain<T> (...iterables: Array<AsyncIterableLike<T>>): AsyncIterableIterator<T>
 export declare function asyncConcat<T> (...iterables: Array<AsyncIterableLike<T>>): AsyncIterableIterator<T>
 
-export declare function asyncConsume<T> (func: (item: T) => void): (iterable: AsyncIterableLike<T>) => void
-export declare function asyncConsume<T> (func: (item: T) => void, iterable: AsyncIterableLike<T>): void
+export declare function asyncConsume<T> (func: (item: T) => MaybePromise<void>): (iterable: AsyncIterableLike<T>) => void
+export declare function asyncConsume<T> (func: (item: T) => MaybePromise<void>, iterable: AsyncIterableLike<T>): void
 
 export declare function asyncCompress<T> (
     iterable: AsyncIterableLike<T>,
@@ -393,29 +394,41 @@ export declare function asyncCursor<T, Filler> (
   iter: AsyncIterable<T>
 ): AsyncIterableIterator<Array<T | Filler>>
 
-export declare function asyncDropWhile<T> (func: (item: T) => boolean):
+export declare function asyncDropWhile<T> (func: (item: T) => MaybePromise<boolean>):
     (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<T>
-export declare function asyncDropWhile<T> (func: (item: T) => boolean, iterable: AsyncIterableLike<T>):
-    AsyncIterableIterator<T>
+export declare function asyncDropWhile<T> (
+  func: (item: T) => MaybePromise<boolean>,
+  iterable: AsyncIterableLike<T>
+): AsyncIterableIterator<T>
 
 export declare function asyncEnumerate<T> (iterable: AsyncIterableLike<T>, start?: number):
     AsyncIterableIterator<[number, T]>
 
-export declare function asyncEvery<T> (func: (item: T) => boolean): (iterable: AsyncIterableLike<T>) => boolean
-export declare function asyncEvery<T> (func: (item: T) => boolean, iterable: AsyncIterableLike<T>): boolean
+export declare function asyncEvery<T> (func: (item: T) => MaybePromise<boolean>):
+  (iterable: AsyncIterableLike<T>) => boolean
+export declare function asyncEvery<T> (
+  func: (item: T) => MaybePromise<boolean>,
+  iterable: AsyncIterableLike<T>
+): boolean
 
 export declare function asyncExecute<T, Args extends any[] = any[]> (
   func: (...args: Args) => Promise<T>,
   ...args: Args
 ): AsyncIterableIterator<T>
 
-export declare function asyncFilter<T> (func: (item: T) => boolean):
+export declare function asyncFilter<T> (func: (item: T) => MaybePromise<boolean>):
     (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<T>
-export declare function asyncFilter<T> (func: (item: T) => boolean, iterable: AsyncIterableLike<T>):
-    AsyncIterableIterator<T>
+export declare function asyncFilter<T> (
+  func: (item: T) => MaybePromise<boolean>,
+  iterable: AsyncIterableLike<T>
+): AsyncIterableIterator<T>
 
-export declare function asyncFind<T> (func: (item: T) => boolean): (iterable: AsyncIterableLike<T>) => T | null
-export declare function asyncFind<T> (func: (item: T) => boolean, iterable: AsyncIterableLike<T>): T | null
+export declare function asyncFind<T> (func: (item: T) => MaybePromise<boolean>):
+  (iterable: AsyncIterableLike<T>) => T | null
+export declare function asyncFind<T> (
+  func: (item: T) => MaybePromise<boolean>,
+  iterable: AsyncIterableLike<T>
+): T | null
 
 export declare function asyncFirst<T> (iterable: AsyncIterableLike<T>): T | undefined
 
@@ -431,10 +444,10 @@ export declare function asyncFlat<
 > (depth: Depth, iter: Iter): AsyncFlatReturn<Depth, Iter>
 export declare function asyncFlat (depth: number, iter: AsyncIterableLike<any>): AsyncIterableIterator<any>
 export declare function asyncFlat (
-  shouldFlat: (depth: number, iter: any) => boolean,
+  shouldFlat: (depth: number, iter: any) => MaybePromise<boolean>,
   iter: AsyncIterableLike<any>
 ): AsyncIterableIterator<any>
-export declare function asyncFlat (shouldFlat: (depth: number, iter: any) => boolean):
+export declare function asyncFlat (shouldFlat: (depth: number, iter: any) => MaybePromise<boolean>):
   (iter: AsyncIterable<any>) => AsyncIterableIterator<any>
 
 export declare function asyncFlatMap<T, O> (func: (item: T) => AsyncIterableLike<O>):
@@ -448,10 +461,12 @@ export declare function asyncGroupBy<T> (
   key: null,
   iterable: AsyncIterableLike<T>
 ): AsyncIterableIterator<[T, AsyncIterableIterator<T>]>
-export declare function asyncGroupBy<T, K> (key: (item: T) => K):
+export declare function asyncGroupBy<T, K> (key: (item: T) => MaybePromise<K>):
   (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<[K, AsyncIterableIterator<T>]>
-export declare function asyncGroupBy<T, K> (key: (item: T) => K, iterable: AsyncIterableLike<T>):
-  AsyncIterableIterator<[K, AsyncIterableIterator<T>]>
+export declare function asyncGroupBy<T, K> (
+  key: (item: T) => MaybePromise<K>,
+  iterable: AsyncIterableLike<T>
+): AsyncIterableIterator<[K, AsyncIterableIterator<T>]>
 
 export declare function asyncInterpose<T, I> (interposeItem: I): (iter: AsyncIterableLike<T>) => AsyncIterableIterator<T | I>
 export declare function asyncInterpose<T, I> (interposeItem: I, iter: AsyncIterableLike<T>): AsyncIterableIterator<T | I>
@@ -460,20 +475,29 @@ export declare function asyncIterable<T> (
   asyncIterator: { next: () => Promise<{value: T}> } | AsyncIterableLike<T>
 ): AsyncIterableIterator<T>
 
-export declare function asyncMap<T, O> (func: (item: T) => O): (iter: AsyncIterableLike<T>) => AsyncIterableIterator<O>
-export declare function asyncMap<T, O> (func: (item: T) => O, iter: AsyncIterableLike<T>): AsyncIterableIterator<O>
+export declare function asyncMap<T, O> (func: (item: T) => MaybePromise<O>):
+  (iter: AsyncIterableLike<T>) => AsyncIterableIterator<O>
+export declare function asyncMap<T, O> (
+  func: (item: T) => MaybePromise<O>,
+  iter: AsyncIterableLike<T>
+): AsyncIterableIterator<O>
 
 export declare function asyncMerge<T> (pickFunc: AsyncMergePickFunc<T>): (iterables: ReadonlyArray<AsyncIterableLike<T>>) => AsyncIterableIterator<T>
 export declare function asyncMerge<T> (pickFunc: AsyncMergePickFunc<T>, iterables: ReadonlyArray<AsyncIterableLike<T>>): AsyncIterableIterator<T>
 
 export declare function asyncReduce<T, O> (func: (acc: O, item: T, c: number) => O):
     (iterable: AsyncIterableLike<T>) => O
-export declare function asyncReduce<T, O> (initial: O, func: (acc: O, item: T, c: number) => O):
-    (iterable: AsyncIterableLike<T>) => O
-export declare function asyncReduce<T, O> (func: (acc: O, item: T, c: number) => O, iterable: AsyncIterableLike<T>): O
+export declare function asyncReduce<T, O> (
+  initial: O,
+  func: (acc: O, item: T, c: number) => MaybePromise<O>
+): (iterable: AsyncIterableLike<T>) => O
+export declare function asyncReduce<T, O> (
+  func: (acc: O, item: T, c: number) => MaybePromise<O>,
+  iterable: AsyncIterableLike<T>
+): O
 export declare function asyncReduce<T, O> (
     initial: O,
-    func: (acc: O, item: T, c: number) => O,
+    func: (acc: O, item: T, c: number) => MaybePromise<O>,
     iterable: AsyncIterableLike<T>
 ): O
 
@@ -484,16 +508,19 @@ export declare function asyncSlice<T> (
     iterable: AsyncIterableLike<T>
 ): AsyncIterableIterator<T>
 
-export declare function asyncTakeWhile<T> (func: (item: T) => boolean):
-    (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<T>
-export declare function asyncTakeWhile<T> (func: (item: T) => boolean, iterable: AsyncIterableLike<T>):
-    AsyncIterableIterator<T>
+export declare function asyncTakeWhile<T> (func: (item: T) => MaybePromise<boolean>):
+  (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<T>
+export declare function asyncTakeWhile<T> (
+  func: (item: T) => MaybePromise<boolean>,
+  iterable: AsyncIterableLike<T>
+): AsyncIterableIterator<T>
 
-export declare function asyncTap<T> (func: (item: T, c: number) => any, iterable: AsyncIterableLike<T>):
-    AsyncIterableIterator<T>
+export declare function asyncTap<T> (
+  func: (item: T, c: number) => MaybePromise<void>,
+  iterable: AsyncIterableLike<T>
+): AsyncIterableIterator<T>
 
-export declare function asyncTakeSorted<T> (n: number, func?: (item: T) => boolean):
-    (iterable: AsyncIterableLike<T>) => AsyncIterableLike<T>
+export declare function asyncTakeSorted<T> (n: number, func?: (item: T) => boolean): (iterable: AsyncIterableLike<T>) => AsyncIterableLike<T>
 export declare function asyncTakeSorted<T> (n: number, func?: (item: T) => boolean, iterable?: AsyncIterableLike<T>):
     AsyncIterableLike<T>
 
@@ -518,8 +545,12 @@ export declare function asyncRegexpExecIter (re: RegExp, iterable: AsyncIterable
 
 export declare function asyncSplitLines (iterable: AsyncIterableLike<string>): AsyncIterableLike<string>
 
-export declare function asyncSome<T> (func: (item: T) => boolean): (iterable: AsyncIterableLike<T>) => boolean
-export declare function asyncSome<T> (func: (item: T) => boolean, iterable: AsyncIterableLike<T>): boolean
+export declare function asyncSome<T> (func: (item: T) => MaybePromise<boolean>):
+  (iterable: AsyncIterableLike<T>) => boolean
+export declare function asyncSome<T> (
+  func: (item: T) => MaybePromise<boolean>,
+  iterable: AsyncIterableLike<T>
+): boolean
 
 export declare function asyncBuffer<T> (n: number): (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<T>
 export declare function asyncBuffer<T> (n: number, iterable: AsyncIterableLike<T>): AsyncIterableIterator<T>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -405,11 +405,11 @@ export declare function asyncEnumerate<T> (iterable: AsyncIterableLike<T>, start
     AsyncIterableIterator<[number, T]>
 
 export declare function asyncEvery<T> (func: (item: T) => MaybePromise<boolean>):
-  (iterable: AsyncIterableLike<T>) => boolean
+  (iterable: AsyncIterableLike<T>) => Promise<boolean>
 export declare function asyncEvery<T> (
   func: (item: T) => MaybePromise<boolean>,
   iterable: AsyncIterableLike<T>
-): boolean
+): Promise<boolean>
 
 export declare function asyncExecute<T, Args extends any[] = any[]> (
   func: (...args: Args) => Promise<T>,
@@ -486,20 +486,20 @@ export declare function asyncMerge<T> (pickFunc: AsyncMergePickFunc<T>): (iterab
 export declare function asyncMerge<T> (pickFunc: AsyncMergePickFunc<T>, iterables: ReadonlyArray<AsyncIterableLike<T>>): AsyncIterableIterator<T>
 
 export declare function asyncReduce<T, O> (func: (acc: O, item: T, c: number) => O):
-    (iterable: AsyncIterableLike<T>) => O
+  (iterable: AsyncIterableLike<T>) => Promise<O>
 export declare function asyncReduce<T, O> (
   initial: O,
   func: (acc: O, item: T, c: number) => MaybePromise<O>
-): (iterable: AsyncIterableLike<T>) => O
+): (iterable: AsyncIterableLike<T>) => Promise<O>
 export declare function asyncReduce<T, O> (
   func: (acc: O, item: T, c: number) => MaybePromise<O>,
   iterable: AsyncIterableLike<T>
-): O
+): Promise<O>
 export declare function asyncReduce<T, O> (
     initial: O,
     func: (acc: O, item: T, c: number) => MaybePromise<O>,
     iterable: AsyncIterableLike<T>
-): O
+): Promise<O>
 
 export declare function asyncSize (iterable: AsyncIterable<any>): number
 
@@ -546,11 +546,11 @@ export declare function asyncRegexpExecIter (re: RegExp, iterable: AsyncIterable
 export declare function asyncSplitLines (iterable: AsyncIterableLike<string>): AsyncIterableLike<string>
 
 export declare function asyncSome<T> (func: (item: T) => MaybePromise<boolean>):
-  (iterable: AsyncIterableLike<T>) => boolean
+  (iterable: AsyncIterableLike<T>) => Promise<boolean>
 export declare function asyncSome<T> (
   func: (item: T) => MaybePromise<boolean>,
   iterable: AsyncIterableLike<T>
-): boolean
+): Promise<boolean>
 
 export declare function asyncBuffer<T> (n: number): (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<T>
 export declare function asyncBuffer<T> (n: number, iterable: AsyncIterableLike<T>): AsyncIterableIterator<T>


### PR DESCRIPTION
**Then:** They return bare values (synchronously)
**Now:** They return promises
**Note:** This pull request includes changes from https://github.com/sithmel/iter-tools/pull/97 and https://github.com/sithmel/iter-tools/pull/96
