### PR TITLE
parallel map/filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  -  async function can take an async callback
  -  find, asyncFind: they return undefined when an item has not been found
 
+### Changed
+ -  async-map, async-filter takes an extra optional argument "concurrency"
+
 ## [6.1.7] - 2018-11-06
 ### Fixed
  -  Added polyfills to transpiled versions

--- a/README.md
+++ b/README.md
@@ -253,6 +253,11 @@ await asyncMap(animal => animal.kind, [
   Promise.resolve({type: 'dog'})
 ]); // ['cat', 'dog']
 ```
+It can also use as extra argument, the concurrency level (default 1):
+```js
+await asyncMap(2, asyncFunction, iterable);
+```
+If this is used, more than one asyncFunction can run concurrently.
 
 ## filter
 The equivalent of the array "filter" function.
@@ -267,6 +272,11 @@ await asyncFilter(animal => animal.kind.slice(1) === 'at', [
 
 ## async-filter
 See filter. The first argument can be a function returning synchronously or a promise.
+It can also use as extra argument, the concurrency level (default 1):
+```js
+await asyncFilter(2, asyncFunction, iterable);
+```
+If this is used, more than one asyncFunction can run concurrently.
 
 ## take-while
 It returns values as soon as the function is true. Then it stops.

--- a/benchmarks/async-map-parallel.js
+++ b/benchmarks/async-map-parallel.js
@@ -1,0 +1,36 @@
+const range = require('../es2018/range')
+const asyncMap = require('../es2018/async-map')
+const asyncReduce = require('../es2018/async-reduce')
+
+const delay = (n) => new Promise((resolve) => setTimeout(resolve, n))
+
+async function power2 (x) {
+  await delay(20)
+  return x * x
+}
+
+function concat (acc, n) {
+  return acc.concat(n)
+}
+
+const a = Array.from(range(100))
+
+module.exports['iter-tools async map 100 items'] = {
+  fn: async function (deferred) {
+    const iter = asyncMap(power2)
+
+    await asyncReduce([], concat, iter(a))
+    deferred.resolve()
+  },
+  defer: true
+}
+
+module.exports['iter-tools async map 100 parallel items'] = {
+  fn: async function (deferred) {
+    const iter = asyncMap(4, power2)
+
+    await asyncReduce([], concat, iter(a))
+    deferred.resolve()
+  },
+  defer: true
+}

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -9,7 +9,8 @@ run([
   bench('compose 100000 items', require('./compose-100000')),
   bench('regexp', require('./regexp-10000')),
   bench('while - for', require('./while-for-10000')),
-  bench('async-map 1000 items', require('./async-map-1000'))
+  bench('async-map 1000 items', require('./async-map-1000')),
+  bench('async-map parallel', require('./async-map-parallel'))
 ])
 
 function bench (title, config) {

--- a/src/__test__/filter.test.js
+++ b/src/__test__/filter.test.js
@@ -38,6 +38,11 @@ describe('asyncFilter', function () {
     expect(await asyncToArray(iter)).toEqual([2, 4, 6])
   })
 
+  it('filters concurrently', async function () {
+    const iter = asyncFilter(2, (item) => item % 2 === 0, range({ start: 1, end: 7 }))
+    expect(await asyncToArray(iter)).toEqual([2, 4, 6])
+  })
+
   it('returns filtered iterable (curried version)', async function () {
     const iter = asyncFilter(function (item) { return item % 2 === 0 })
     expect(await asyncToArray(iter(range({ start: 1, end: 7 })))).toEqual([2, 4, 6])

--- a/src/__test__/map.test.js
+++ b/src/__test__/map.test.js
@@ -38,6 +38,11 @@ describe('asyncMap', function () {
     expect(await asyncToArray(iter)).toEqual([2, 4, 6])
   })
 
+  it('maps concurrently', async function () {
+    const iter = asyncMap(2, (item) => item * 2, range({ start: 1, end: 4 }))
+    expect(await asyncToArray(iter)).toEqual([2, 4, 6])
+  })
+
   it('returns mapped iterable (curried version)', async function () {
     const iter = asyncMap((item) => item * 2)
     expect(await asyncToArray(iter(range({ start: 1, end: 4 })))).toEqual([2, 4, 6])

--- a/src/__test__/merge.test.js
+++ b/src/__test__/merge.test.js
@@ -73,6 +73,6 @@ describe('asyncMerge', function () {
     } catch (e) {
       error = e
     }
-    expect(error.message).toEqual('iter-tools, merge: no sequence is ready after the configured interval')
+    expect(error.message).toEqual('async-merge: no sequence is ready after the configured interval')
   })
 })

--- a/src/async-batch.mjs
+++ b/src/async-batch.mjs
@@ -1,6 +1,7 @@
 import ensureAsyncIterable from './internal/ensure-async-iterable'
 
 async function * batch (number, iterable) {
+  if (typeof number !== 'number' || number < 1) throw new Error('batch size should be a number, greater than zero')
   let batch = []
   for await (const item of ensureAsyncIterable(iterable)) {
     batch.push(item)

--- a/src/async-flat.mjs
+++ b/src/async-flat.mjs
@@ -10,7 +10,7 @@ const defaultShouldIFlat = (depth) => {
       (typeof iter[Symbol.iterator] === 'function' || typeof iter[Symbol.asyncIterator] === 'function') &&
       typeof iter !== 'string'
   }
-  throw new Error('flat: "depth" can be a function or a number')
+  throw new Error('async-flat: "depth" can be a function or a number')
 }
 
 function asyncFlat (shouldIFlat, iterable) {

--- a/src/async-merge.mjs
+++ b/src/async-merge.mjs
@@ -18,10 +18,10 @@ async function * asyncMerge (pickFunc, iterables) {
       // pick and return the item
       const chosen = await pickFunc(items)
       if (typeof items[chosen] === 'undefined') {
-        throw new Error('iter-tools, merge: the sequence returned doesn\'t exist')
+        throw new Error('async-merge: the sequence returned doesn\'t exist')
       }
       if (items[chosen] === null) {
-        throw new Error('iter-tools, async-merge: the sequence returned is exhausted')
+        throw new Error('async-merge: the sequence returned is exhausted')
       }
       const { done, value } = await items[chosen]
       if (done) {
@@ -63,7 +63,7 @@ export const asyncMergeByPosition = makeAsync(mergeByPosition)
 
 const expire = (ms) =>
   new Promise((resolve, reject) =>
-    setTimeout(() => reject(new Error('iter-tools, merge: no sequence is ready after the configured interval')), ms))
+    setTimeout(() => reject(new Error('async-merge: no sequence is ready after the configured interval')), ms))
 
 export function asyncMergeByReadiness (ms) {
   return async function _asyncMergeByReadiness (promises) {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -434,6 +434,20 @@ export declare function asyncFilter<T> (
   func: (item: T) => MaybePromise<boolean>,
   iterable: AsyncIterableLike<T>
 ): AsyncIterableIterator<T>
+export declare function asyncFilter<S extends T, T> (concurrency: number, func: (item: T) => item is S):
+  (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<S>
+export declare function asyncFilter<S extends T, T> (
+  concurrency: number,
+  func: (item: T) => item is S,
+  iterable: AsyncIterableLike<T>
+): AsyncIterableIterator<S>
+export declare function asyncFilter<T> (concurrency: number, func: (item: T) => MaybePromise<boolean>):
+  (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<T>
+export declare function asyncFilter<T> (
+  concurrency: number,
+  func: (item: T) => MaybePromise<boolean>,
+  iterable: AsyncIterableLike<T>
+): AsyncIterableIterator<T>
 
 export declare function asyncFind<S extends T, T> (func: (item: T) => item is S):
   (iterable: AsyncIterableLike<T>) => Promise<S | null>
@@ -496,6 +510,13 @@ export declare function asyncIterable<T> (
 export declare function asyncMap<T, O> (func: (item: T) => MaybePromise<O>):
   (iter: AsyncIterableLike<T>) => AsyncIterableIterator<O>
 export declare function asyncMap<T, O> (
+  func: (item: T) => MaybePromise<O>,
+  iter: AsyncIterableLike<T>
+): AsyncIterableIterator<O>
+export declare function asyncMap<T, O> (concurrency: number, func: (item: T) => MaybePromise<O>):
+  (iter: AsyncIterableLike<T>) => AsyncIterableIterator<O>
+export declare function asyncMap<T, O> (
+  concurrency: number,
   func: (item: T) => MaybePromise<O>,
   iter: AsyncIterableLike<T>
 ): AsyncIterableIterator<O>

--- a/src/merge.mjs
+++ b/src/merge.mjs
@@ -16,10 +16,10 @@ function * merge (pickFunc, iterables) {
       // pick and return the item
       const chosen = pickFunc(items)
       if (typeof items[chosen] === 'undefined') {
-        throw new Error('iter-tools, merge: the sequence returned doesn\'t exist')
+        throw new Error('the sequence returned doesn\'t exist')
       }
       if (items[chosen] === null) {
-        throw new Error('iter-tools, merge: the sequence returned is exhausted')
+        throw new Error('the sequence returned is exhausted')
       }
       const { done, value } = items[chosen]
       if (done) {

--- a/src/regexp-exec.mjs
+++ b/src/regexp-exec.mjs
@@ -1,7 +1,7 @@
 import cloneRegexp from './internal/clone-regexp'
 
 function * regexpExec (re, str) {
-  if (typeof str !== 'string') throw new Error('iter-tools - regexpExec: it should take a string')
+  if (typeof str !== 'string') throw new Error('regexpExec: it should take a string')
   let match
   while ((match = re.exec(str)) !== null) {
     yield match

--- a/src/regexp-split.mjs
+++ b/src/regexp-split.mjs
@@ -1,7 +1,7 @@
 import cloneRegexp from './internal/clone-regexp'
 
 function * regexpSplit (re, str) {
-  if (typeof str !== 'string') throw new Error('iter-tools - regexpSplit: it should take a string')
+  if (typeof str !== 'string') throw new Error('regexpSplit: it should take a string')
   let i, match
   if (!re) {
     yield * str


### PR DESCRIPTION
This implements an additional (optional) parameter for async-map and async-filter that allows to do operations concurrently.

This is currently missing:
- documentation
- tests
- type declarations

The reason why I opted for this rather then building two new functions are:
* the function returns basically the same values, so it was difficult and counterproductive using a different names
* the implementation for "concurrency=1" is equivalent to the plain asyncMap/asyncFilter