### PR TITLE
Use native map() in tee()

### DIFF
--- a/src/tee.mjs
+++ b/src/tee.mjs
@@ -1,5 +1,4 @@
 import range from './range'
-import map from './map'
 import ensureIterable from './internal/ensure-iterable'
 import Dequeue from 'dequeue'
 
@@ -8,7 +7,7 @@ export default function tee (iterable, number) {
   const iterator = ensureIterable(iterable)[Symbol.iterator]()
 
   let exhausted = 0
-  const arrays = Array.from(map(() => new Dequeue(), range(number)))
+  const arrays = Array.from(range(number)).map(() => new Dequeue())
   let done = false
 
   function fetch () {


### PR DESCRIPTION
- Webpack users that don't use iter-tools `map()` may benefit from tree-shaking
- Native `map()` should be faster since it runs in native code