### PR TITLE
Fix type definition of compose() and pipeline()

### DIFF
--- a/src/__spec__/compose.spec.ts
+++ b/src/__spec__/compose.spec.ts
@@ -1,0 +1,21 @@
+import assert from 'static-type-assert'
+import { compose, map, filter } from '../index'
+
+const func = compose<Iterable<number>>(
+  filter(x => {
+    assert<number>(x)
+    return x % 2 === 1
+  }),
+  map(x => {
+    assert<number>(x)
+    return x + 2
+  })
+)
+
+assert<
+  (iter: Iterable<number>) => Iterable<number>
+>(func)
+
+assert<
+  Iterable<number>
+>(func([0, 1, 2, 3]))

--- a/src/__spec__/pipeline.spec.ts
+++ b/src/__spec__/pipeline.spec.ts
@@ -1,0 +1,32 @@
+import assert from 'static-type-assert'
+import { pipeline, range, map, filter } from '../index'
+
+{ // using function
+  const func = pipeline(
+    () => range(12) as Iterable<number>,
+    filter(x => {
+      assert<number>(x)
+      return x % 2 === 1
+    }),
+    map(x => {
+      assert<number>(x)
+      return x + 2
+    })
+  )
+
+  assert<() => Iterable<number>>(func)
+  assert<Iterable<number>>(func())
+}
+
+{ // using composition
+  const func = pipeline(
+    filter((x: number) => x % 2 === 1),
+    map(x => {
+      assert<number>(x)
+      return x + 2
+    })
+  )
+
+  assert<(iter: Iterable<number>) => Iterable<number>>(func)
+  assert<Iterable<number>>(func([0, 1, 2, 3]))
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -157,7 +157,7 @@ export declare function concat<T> (...iterables: Array<Iterable<T>>): IterableIt
 export declare const combinations: CombinationsPermutations
 export declare const combinationsWithReplacement: CombinationsPermutations
 
-export declare function compose<T> (fns: Iterable<(_: T) => T>): IterableIterator<T>
+export declare function compose<T> (...fns: ((x: T) => T)[]): (x: T) => T
 
 export declare function compress<T> (iterable: Iterable<T>, compress: Iterable<boolean>): IterableIterator<T>
 
@@ -282,7 +282,13 @@ export declare function merge<T> (pickFunc: MergePickFunc<T>, iterables: Readonl
 
 export declare const permutations: CombinationsPermutations
 
-export declare function pipeline<T> (fns: Iterable<(_: T) => T>): IterableIterator<T>
+export declare function pipeline<
+  Args extends any[],
+  T
+> (
+  init: (...args: Args) => T,
+  ...fns: ((x: T) => T)[]
+): (...args: Args) => T
 
 export declare function product<Args extends Array<Iterable<any>>> (...iterables: Args):
   Iterable<ProductReturnElement<Args>> & { getSize: () => number }


### PR DESCRIPTION
- Last time I checked, compose() has correct definition, someone changed it 🤔
- Before this commit, the type definition is totally incorrect
- The commit fixes these type
- It's simple for now, I may try to improve it in the future