### PR TITLE
Fix type definition of iterable(), asyncIterable() and cycle()

### DIFF
--- a/src/__spec__/cycle.spec.ts
+++ b/src/__spec__/cycle.spec.ts
@@ -18,3 +18,7 @@ assert<
 assert<
   IterableIterator<string>
 >(iter.cycle(iter.iterable('')))
+
+assert<
+  IterableIterator<0 | 1 | 2>
+>(iter.cycle(new Set<0 | 1 | 2>()))

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -272,7 +272,11 @@ export declare function groupBy<T, K> (
 export declare function interpose<T, I> (interposeItem: I): (iter: Iterable<T>) => IterableIterator<T | I>
 export declare function interpose<T, I> (interposeItem: I, iter: Iterable<T>): IterableIterator<T | I>
 
-export declare function iterable<T> (iterator: { next: () => {value: T} } | Iterable<T>): IterableIterator<T>
+export declare function iterable<T> (
+  iterator: {
+    readonly next: () => IteratorResult<T>
+  } | Iterable<T>
+): Iterable<T>
 
 export declare function map<T, O> (func: (item: T) => O): (iter: Iterable<T>) => IterableIterator<O>
 export declare function map<T, O> (func: (item: T) => O, iter: Iterable<T>): IterableIterator<O>
@@ -505,8 +509,10 @@ export declare function asyncInterpose<T, I> (interposeItem: I): (iter: AsyncIte
 export declare function asyncInterpose<T, I> (interposeItem: I, iter: AsyncIterableLike<T>): AsyncIterableIterator<T | I>
 
 export declare function asyncIterable<T> (
-  asyncIterator: { next: () => Promise<{value: T}> } | AsyncIterableLike<T>
-): AsyncIterableIterator<T>
+  asyncIterator: {
+    readonly next: () => Promise<IteratorResult<T>>
+  } | AsyncIterableLike<T>
+): AsyncIterable<T>
 
 export declare function asyncMap<T, O> (func: (item: T) => MaybePromise<O>):
   (iter: AsyncIterableLike<T>) => AsyncIterableIterator<O>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -9,6 +9,7 @@ type AsyncIterableLike<T> = AsyncIterable<T> | Iterable<T>
 type ReasonableNumber = UnionRange<32>
 type IterableElement<Iter> = Iter extends Iterable<infer X> ? X : never
 type AsyncIterableElement<Iter> = Iter extends AsyncIterableLike<infer X> ? X : never
+type ToIterator<Iter> = IterableIterator<IterableElement<Iter>>
 type MaybePromise<T> = T | Promise<T>
 
 /**
@@ -167,7 +168,7 @@ export declare function consume<T> (func: (item: T) => void, iterable: Iterable<
 export declare function count (opts: number | { start: number, end?: number, step?: number }): IterableIterator<number>
 
 export declare function cycle<Iter extends Iterable<any>> (iterable: Iter):
-  Iter extends any[] ? IterableIterator<UnionFromTuple<Iter>> : Iter
+  Iter extends any[] ? IterableIterator<UnionFromTuple<Iter>> : ToIterator<Iter>
 
 export declare function cursor<T, Size extends ReasonableNumber> (
   opts: {


### PR DESCRIPTION
As @sithmel stated in https://github.com/sithmel/iter-tools/pull/117#issuecomment-454299627, their purpose is to return iterables.

I also fix type definition of `cycle()`. (I planned to create another pull request for this but pushed here by mistake)