### PR TITLE
Fix TypeScript definition of splitAt and asyncSplitAt

### DIFF
--- a/src/__spec__/split-at.spec.ts
+++ b/src/__spec__/split-at.spec.ts
@@ -1,110 +1,18 @@
 import assert from 'static-type-assert'
 import * as iter from '../index'
 
-assert<[
-  IterableIterator<never>,
-  IterableIterator<never>
-]>(iter.splitAt(0, [] as []))
+assert<
+  IterableIterator<IterableIterator<number>>
+>(iter.splitAt(3, [0, 1, 2, 3]))
 
-assert<[
-  IterableIterator<never>,
-  IterableIterator<never>
-]>(iter.splitAt(3, [] as []))
+assert<
+  IterableIterator<IterableIterator<number>>
+>(iter.splitAt(3)([0, 1, 2, 3]))
 
-assert<[
-  IterableIterator<never>,
-  IterableIterator<0 | 1 | 2 | 3 | 4>
-]>(iter.splitAt(0, [0, 1, 2, 3, 4] as [0, 1, 2, 3, 4]))
+assert<
+  IterableIterator<AsyncIterableIterator<number>>
+>(iter.asyncSplitAt(3, [0, 1, 2, 3]))
 
-assert<[
-  IterableIterator<0 | 1 | 2>,
-  IterableIterator<3 | 4>
-]>(iter.splitAt(3, [0, 1, 2, 3, 4] as [0, 1, 2, 3, 4]))
-
-assert<[
-  IterableIterator<'type'>,
-  IterableIterator<'type'>
-]>(iter.splitAt(3, [] as 'type'[]))
-
-assert<[
-  IterableIterator<'type'>,
-  IterableIterator<'type'>
-]>(iter.splitAt(3, [] as Iterable<'type'>))
-
-{
-  const splitAt3 = iter.splitAt(3)
-
-  assert<[
-    IterableIterator<0 | 1 | 2>,
-    IterableIterator<3 | 4>
-  ]>(splitAt3([0, 1, 2, 3, 4] as [0, 1, 2, 3, 4]))
-
-  assert<[
-    IterableIterator<'type'>,
-    IterableIterator<'type'>
-  ]>(splitAt3([] as 'type'[]))
-
-  assert<[
-    IterableIterator<'type'>,
-    IterableIterator<'type'>
-  ]>(splitAt3([] as Iterable<'type'>))
-}
-
-assert<[
-  AsyncIterableIterator<never>,
-  AsyncIterableIterator<never>
-]>(iter.asyncSplitAt(0, [] as []))
-
-assert<[
-  AsyncIterableIterator<never>,
-  AsyncIterableIterator<never>
-]>(iter.asyncSplitAt(3, [] as []))
-
-assert<[
-  AsyncIterableIterator<never>,
-  AsyncIterableIterator<0 | 1 | 2 | 3 | 4>
-]>(iter.asyncSplitAt(0, [0, 1, 2, 3, 4] as [0, 1, 2, 3, 4]))
-
-assert<[
-  AsyncIterableIterator<0 | 1 | 2>,
-  AsyncIterableIterator<3 | 4>
-]>(iter.asyncSplitAt(3, [0, 1, 2, 3, 4] as [0, 1, 2, 3, 4]))
-
-assert<[
-  AsyncIterableIterator<'type'>,
-  AsyncIterableIterator<'type'>
-]>(iter.asyncSplitAt(3, [] as 'type'[]))
-
-assert<[
-  AsyncIterableIterator<'type'>,
-  AsyncIterableIterator<'type'>
-]>(iter.asyncSplitAt(3, [] as Iterable<'type'>))
-
-assert<[
-  AsyncIterableIterator<'type'>,
-  AsyncIterableIterator<'type'>
-]>(iter.asyncSplitAt(3, iter.asyncIterable([] as 'type'[])))
-
-{
-  const asyncSplitAt3 = iter.asyncSplitAt(3)
-
-  assert<[
-    AsyncIterableIterator<0 | 1 | 2>,
-    AsyncIterableIterator<3 | 4>
-  ]>(asyncSplitAt3([0, 1, 2, 3, 4] as [0, 1, 2, 3, 4]))
-
-  assert<[
-    AsyncIterableIterator<'type'>,
-    AsyncIterableIterator<'type'>
-  ]>(asyncSplitAt3([] as 'type'[]))
-
-  assert<[
-    AsyncIterableIterator<'type'>,
-    AsyncIterableIterator<'type'>
-  ]>(asyncSplitAt3([] as Iterable<'type'>))
-
-  assert<[
-    AsyncIterableIterator<'type'>,
-    AsyncIterableIterator<'type'>
-  ]>(asyncSplitAt3(iter.asyncIterable([] as 'type'[])))
-}
+assert<
+  IterableIterator<AsyncIterableIterator<number>>
+>(iter.asyncSplitAt(3)([0, 1, 2, 3]))

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -145,44 +145,6 @@ export interface AsyncMergePickFunc<Value> {
   >): number
 }
 
-export type SplitAtElement<
-  Position extends number,
-  Iter extends any[],
-  First extends any[] = [],
-  Rest extends any[] = []
-> = {
-  matched: [
-    IterableElement<First>,
-    IterableElement<Iter>
-  ]
-  unmatched: ((...args: Iter) => any) extends ((a: infer FirstAddend, ...b: infer NextRest) => any)
-    ? SplitAtElement<
-        Position,
-        NextRest,
-        Prepend<First, FirstAddend>,
-        NextRest
-      >
-    : never
-  outOfBound: [
-    IterableElement<First>,
-    never
-  ]
-}[
-  First['length'] extends Position ? 'matched' :
-  Iter extends [] ? 'outOfBound' :
-  'unmatched'
-]
-
-export type SplitAtArrayReturn<Position extends number, Iter extends any[]> =
-  SplitAtElement<Position, Iter> extends [infer A, infer B]
-    ? [IterableIterator<A>, IterableIterator<B>]
-    : never
-
-export type AsyncSplitAtArrayReturn<Position extends number, Iter extends any[]> =
-  SplitAtElement<Position, Iter> extends [infer A, infer B]
-    ? [AsyncIterableIterator<A>, AsyncIterableIterator<B>]
-    : never
-
 // Sync
 export declare function keys (obj: { [id: string]: any }): IterableIterator<string>
 export declare function values<T> (obj: { [id: string]: T }): IterableIterator<T>
@@ -445,22 +407,12 @@ export declare function slice<T> (
 export declare function some<T> (func: (item: T) => boolean): (iterable: Iterable<T>) => boolean
 export declare function some<T> (func: (item: T) => boolean, iterable: Iterable<T>): boolean
 
-export declare function splitAt<
-  Position extends ReasonableNumber,
-  Iter extends any[]
-> (position: Position, iter: Iter): SplitAtArrayReturn<Position, Iter>
-export declare function splitAt<
-  Position extends ReasonableNumber
-> (position: Position): {
-  <Iter extends any[]> (iter: Iter): SplitAtArrayReturn<Position, Iter>
-  <T> (iter: Iterable<T>): [IterableIterator<T>, IterableIterator<T>]
-}
 export declare function splitAt (position: number):
-  <T> (iterable: Iterable<T>) => [IterableIterator<T>, IterableIterator<T>]
+  <T> (iterable: Iterable<T>) => IterableIterator<IterableIterator<T>>
 export declare function splitAt<T> (
   position: number,
   iterable: Iterable<T>
-): [IterableIterator<T>, IterableIterator<T>]
+): IterableIterator<IterableIterator<T>>
 
 export declare function takeWhile<T> (func: (item: T) => boolean): (iterable: Iterable<T>) => IterableIterator<T>
 export declare function takeWhile<T> (func: (item: T) => boolean, iterable: Iterable<T>): IterableIterator<T>
@@ -777,22 +729,12 @@ export declare function asyncSome<T> (
   iterable: AsyncIterableLike<T>
 ): Promise<boolean>
 
-export declare function asyncSplitAt<
-  Position extends ReasonableNumber,
-  Iter extends any[]
-> (position: Position, iter: Iter): AsyncSplitAtArrayReturn<Position, Iter>
-export declare function asyncSplitAt<
-  Position extends ReasonableNumber
-> (position: Position): {
-  <Iter extends any[]> (iter: Iter): AsyncSplitAtArrayReturn<Position, Iter>
-  <T> (iter: AsyncIterableLike<T>): [AsyncIterableIterator<T>, AsyncIterableIterator<T>]
-}
 export declare function asyncSplitAt (position: number):
-  <T> (iterable: AsyncIterableLike<T>) => [AsyncIterableIterator<T>, AsyncIterableIterator<T>]
+  <T> (iterable: AsyncIterableLike<T>) => IterableIterator<AsyncIterableIterator<T>>
 export declare function asyncSplitAt<T> (
   position: number,
   iterable: AsyncIterableLike<T>
-): [AsyncIterableIterator<T>, AsyncIterableIterator<T>]
+): IterableIterator<AsyncIterableIterator<T>>
 
 export declare function asyncBuffer<T> (n: number): (iterable: AsyncIterableLike<T>) => AsyncIterableIterator<T>
 export declare function asyncBuffer<T> (n: number, iterable: AsyncIterableLike<T>): AsyncIterableIterator<T>


### PR DESCRIPTION
~~**NOTE:** This PR must not be merged until https://github.com/sithmel/iter-tools/issues/194 is resolved.~~ @sithmel You can merge this now

---

Fixes https://github.com/sithmel/iter-tools/issues/192

Closes https://github.com/sithmel/iter-tools/issues/194