### PR TITLE
Convert iterableCurry/asyncIterableCurry args to objects

### DIFF
--- a/src/async-consume.mjs
+++ b/src/async-consume.mjs
@@ -7,4 +7,4 @@ async function asyncConsume (func = () => {}, iterable) {
   }
 }
 
-export default asyncIterableCurry(asyncConsume, { variadic: false, reduces: true }, 0, 1)
+export default asyncIterableCurry(asyncConsume, { variadic: false, reduces: true, minArgs: 0, maxArgs: 1 })

--- a/src/async-filter.mjs
+++ b/src/async-filter.mjs
@@ -17,4 +17,4 @@ async function * asyncFilter (concurrency, func, iterable) {
   }
 }
 
-export default asyncIterableCurry(asyncFilter, { variadic: false }, 1, 2)
+export default asyncIterableCurry(asyncFilter, { variadic: false, minArgs: 1, maxArgs: 2 })

--- a/src/async-flat-map.mjs
+++ b/src/async-flat-map.mjs
@@ -8,4 +8,4 @@ async function * asyncFlatMap (concurrency = 1, func, iterable) {
   }
 }
 
-export default asyncIterableCurry(asyncFlatMap, { variadic: false }, 1, 2)
+export default asyncIterableCurry(asyncFlatMap, { variadic: false, minArgs: 1, maxArgs: 2 })

--- a/src/async-flat.mjs
+++ b/src/async-flat.mjs
@@ -28,4 +28,4 @@ function asyncFlat (shouldIFlat = 1, iterable) {
   return _asyncFlat(0, iterable)
 }
 
-export default asyncIterableCurry(asyncFlat, { variadic: false }, 0, 1)
+export default asyncIterableCurry(asyncFlat, { variadic: false, minArgs: 0, maxArgs: 1 })

--- a/src/async-group-by.mjs
+++ b/src/async-group-by.mjs
@@ -22,4 +22,4 @@ async function * asyncGroupBy (getKey = (k) => k, iterable) {
   }
 }
 
-export default asyncIterableCurry(asyncGroupBy, { variadic: false }, 0, 1)
+export default asyncIterableCurry(asyncGroupBy, { variadic: false, minArgs: 0, maxArgs: 1 })

--- a/src/async-map.mjs
+++ b/src/async-map.mjs
@@ -92,4 +92,4 @@ async function * asyncMap (concurrency = 1, func, iterable) {
   }
 }
 
-export default asyncIterableCurry(asyncMap, undefined, 1, 2)
+export default asyncIterableCurry(asyncMap, { minArgs: 1, maxArgs: 2 })

--- a/src/async-reduce.mjs
+++ b/src/async-reduce.mjs
@@ -23,4 +23,4 @@ async function asyncReduce (initial, func, iterable) {
   }
 }
 
-export default asyncIterableCurry(asyncReduce, { variadic: false, reduces: true }, 1, 2)
+export default asyncIterableCurry(asyncReduce, { variadic: false, reduces: true, minArgs: 1, maxArgs: 2 })

--- a/src/async-take-sorted.mjs
+++ b/src/async-take-sorted.mjs
@@ -15,4 +15,4 @@ async function * asyncTakeSorted (comparator, number, iterable) {
   }
 }
 
-export default asyncIterableCurry(asyncTakeSorted, { variadic: false }, 1, 2)
+export default asyncIterableCurry(asyncTakeSorted, { variadic: false, minArgs: 1, maxArgs: 2 })

--- a/src/consume.mjs
+++ b/src/consume.mjs
@@ -7,4 +7,4 @@ function consume (func = () => {}, iterable) {
   }
 }
 
-export default iterableCurry(consume, { variadic: false, reduces: true }, 0, 1)
+export default iterableCurry(consume, { variadic: false, reduces: true, minArgs: 0, maxArgs: 1 })

--- a/src/flat.mjs
+++ b/src/flat.mjs
@@ -25,4 +25,4 @@ function flat (shouldIFlat = 1, iterable) {
   return _flat(0, iterable)
 }
 
-export default iterableCurry(flat, { variadic: false }, 0, 1)
+export default iterableCurry(flat, { variadic: false, minArgs: 0, maxArgs: 1 })

--- a/src/group-by.mjs
+++ b/src/group-by.mjs
@@ -22,4 +22,4 @@ function * groupBy (getKey = (k) => k, iterable) {
   }
 }
 
-export default iterableCurry(groupBy, { variadic: false }, 0, 1)
+export default iterableCurry(groupBy, { variadic: false, minArgs: 0, maxArgs: 1 })

--- a/src/internal/__tests__/async-iterable.test.js
+++ b/src/internal/__tests__/async-iterable.test.js
@@ -85,7 +85,7 @@ describe('asyncIterableCurry', function () {
 
   describe('when passed explicit arity', function () {
     const f = (a = goodbye, b = world, c) => iter(a, b)
-    const c = asyncIterableCurry(f, undefined, 0, 2)
+    const c = asyncIterableCurry(f, { minArgs: 0, maxArgs: 2 })
 
     it('curries', async function () {
       expect(await asyncToArray(c(hello)(world)([]))).toEqual([hello, world])

--- a/src/internal/__tests__/iterable.test.js
+++ b/src/internal/__tests__/iterable.test.js
@@ -90,7 +90,7 @@ describe('iterableCurry', function () {
 
   describe('when passed explicit arity', function () {
     const f = (a = goodbye, b = world, c) => iter(a, b)
-    const c = iterableCurry(f, undefined, 0, 2)
+    const c = iterableCurry(f, { minArgs: 0, maxArgs: 2 })
 
     it('curries', function () {
       expect(toArray(c(hello)(world)([]))).toEqual([hello, world])

--- a/src/internal/async-iterable.mjs
+++ b/src/internal/async-iterable.mjs
@@ -1,4 +1,4 @@
-import { ensureIterable, isValidIterableArgument } from './iterable'
+import { BaseIterable, Iterable, ensureIterable, isValidIterableArgument } from './iterable'
 import { variadicCurryWithValidation } from './curry'
 
 export function isAsyncIterable (i) {
@@ -28,16 +28,31 @@ export function isValidAsyncIterableArgument (i) {
   return isAsyncIterable(i) || isValidIterableArgument(i)
 }
 
-export const asyncIterableCurry = (fn, { variadic = false, reduces = false, forceSync = false } = {}, minArgs, maxArgs) => {
-  return variadicCurryWithValidation(
-    isValidAsyncIterableArgument,
-    'asyncIterable',
-    ensureAsyncIterable,
+export function AsyncIterable () { BaseIterable.apply(this, arguments) }
+
+AsyncIterable.prototype = Object.assign(Object.create(BaseIterable.prototype), {
+  constructor: AsyncIterable,
+  [Symbol.asyncIterator] () {
+    return this.__iterate()
+  }
+})
+
+function combineFunctionConfig (fn, fnConfig) {
+  const { variadic, reduces, minArgs, maxArgs, forceSync } = fnConfig
+
+  return {
     fn,
-    variadic,
-    reduces,
-    forceSync,
-    minArgs,
-    maxArgs
-  )
+    variadic: !!variadic,
+    reduces: !!reduces,
+    minArgs: minArgs === undefined ? fn.length - 1 : minArgs,
+    maxArgs: maxArgs === undefined ? variadic ? fn.length : fn.length - 1 : maxArgs,
+    isIterable: isValidAsyncIterableArgument,
+    iterableType: 'asyncIterable',
+    applyOnIterableArgs: ensureAsyncIterable,
+    IterableClass: forceSync ? Iterable : AsyncIterable
+  }
+}
+
+export const asyncIterableCurry = (fn, config = {}) => {
+  return variadicCurryWithValidation(combineFunctionConfig(fn, config))
 }

--- a/src/reduce.mjs
+++ b/src/reduce.mjs
@@ -23,4 +23,4 @@ function reduce (initial, func, iterable) {
   }
 }
 
-export default iterableCurry(reduce, { variadic: false, reduces: true }, 1, 2)
+export default iterableCurry(reduce, { variadic: false, reduces: true, minArgs: 1, maxArgs: 2 })

--- a/src/take-sorted.mjs
+++ b/src/take-sorted.mjs
@@ -15,4 +15,4 @@ function * takeSorted (comparator, number, iterable) {
   }
 }
 
-export default iterableCurry(takeSorted, { variadic: false }, 1, 2)
+export default iterableCurry(takeSorted, { variadic: false, minArgs: 1, maxArgs: 2 })


### PR DESCRIPTION
The configuration objects need only be created once at parse time.
Doing this should save on both bundle size and execution time