### PR TITLE
Improve flat API

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,11 @@ const isString = item => typeof item === 'string' && item.length > 1
 flat(isString, Infinity, ['hel', ['lo', ''], ['world']]); // h e l l o w o r l d
 ```
 
+Finally for maximum readability you can specify flat's options as an object, like so:
+```js
+flat({ shouldFlat: isString, depth: Infinity }, ['hel', ['lo', ''], ['world']]); // h e l l o w o r l d
+```
+
 ## async-flat
 Same as flat but works on both sync and async iterables.
 

--- a/README.md
+++ b/README.md
@@ -384,11 +384,11 @@ flat([1, [2, 3], [4, [5, 6]]]); // 1, 2, 3, 4, [5, 6]
 flat(2, [1, [2, 3], [4, [5, 6]]]); // 1, 2, 3, 4, 5, 6
 ```
 The algorithm takes into consideration every item that is iterable, except strings.
-Alternatively, you can pass a function that takes the current "depth" and "item" and returns true if the "item" is a sequence and it needs to be flatten.
+Alternatively, you can pass a function that takes the current item and returns true if the item is a sequence which can be flattened.
 ```js
-const isNotACharacter = (depth, item) => !(typeof item === 'string' && item.length <= 1)
+const isString = item => typeof item === 'string' && item.length > 1
 
-flat(isNotACharacter, ['hel', ['lo', ''], ['world']]); // h e l l o w o r l d
+flat(isString, Infinity, ['hel', ['lo', ''], ['world']]); // h e l l o w o r l d
 ```
 
 ## async-flat

--- a/src/__tests__/flat.test.js
+++ b/src/__tests__/flat.test.js
@@ -43,7 +43,7 @@ describe('flat', function () {
   })
 
   it('flats using custom function', function () {
-    const iter = flat((depth, iter) => !(typeof iter === 'string' && iter.length === 1), [['a', 'b'], ['c', ['d', 'e']], [['fghi']]])
+    const iter = flat(iter => !(typeof iter === 'string' && iter.length === 1), Infinity, [['a', 'b'], ['c', ['d', 'e']], [['fghi']]])
     expect(Array.from(iter)).toEqual(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'])
   })
 })
@@ -90,12 +90,12 @@ describe('asyncFlat', function () {
   })
 
   it('flats using custom function', async function () {
-    const iter = asyncFlat((depth, iter) => !(typeof iter === 'string' && iter.length === 1), [['a', 'b'], ['c', ['d', 'e']], [['fghi']]])
+    const iter = asyncFlat(iter => !(typeof iter === 'string' && iter.length === 1), Infinity, [['a', 'b'], ['c', ['d', 'e']], [['fghi']]])
     expect(await asyncToArray(iter)).toEqual(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'])
   })
 
   it('flats using custom function (using a promise)', async function () {
-    const iter = asyncFlat(async (depth, iter) => !(typeof iter === 'string' && iter.length === 1), [['a', 'b'], ['c', ['d', 'e']], [['fghi']]])
+    const iter = asyncFlat(async iter => !(typeof iter === 'string' && iter.length === 1), Infinity, [['a', 'b'], ['c', ['d', 'e']], [['fghi']]])
     expect(await asyncToArray(iter)).toEqual(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'])
   })
 })

--- a/src/__tests__/flat.test.js
+++ b/src/__tests__/flat.test.js
@@ -23,8 +23,8 @@ describe('flat', function () {
   })
 
   it('flats iterable depth 0', function () {
-    const iter = flat(0, [[1, 2], [3, 4], [5]])
-    expect(Array.from(iter)).toEqual([[1, 2], [3, 4], [5]])
+    const iter = flat(0, [[1, 2], [3]])
+    expect(Array.from(iter)).toEqual([[1, 2], [3]])
   })
 
   it('flats iterable depth 2', function () {
@@ -45,6 +45,18 @@ describe('flat', function () {
   it('flats using custom function', function () {
     const iter = flat(iter => !(typeof iter === 'string' && iter.length === 1), Infinity, [['a', 'b'], ['c', ['d', 'e']], [['fghi']]])
     expect(Array.from(iter)).toEqual(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'])
+  })
+
+  describe('repects options passed as an object', function () {
+    it('flats iterable depth 2', function () {
+      const iter = flat({ depth: 2 }, [[1, 2], [3, [4, 5]], [[6]]])
+      expect(Array.from(iter)).toEqual([1, 2, 3, 4, 5, 6])
+    })
+
+    it('flats using custom function', function () {
+      const iter = flat({ shouldFlat: iter => !(typeof iter === 'string' && iter.length === 1), depth: Infinity }, [['a', 'b'], ['c', ['d', 'e']], [['fghi']]])
+      expect(Array.from(iter)).toEqual(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'])
+    })
   })
 })
 
@@ -97,5 +109,17 @@ describe('asyncFlat', function () {
   it('flats using custom function (using a promise)', async function () {
     const iter = asyncFlat(async iter => !(typeof iter === 'string' && iter.length === 1), Infinity, [['a', 'b'], ['c', ['d', 'e']], [['fghi']]])
     expect(await asyncToArray(iter)).toEqual(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'])
+  })
+
+  describe('repects options passed as an object', function () {
+    it('flats iterable depth 2', async function () {
+      const iter = asyncFlat({ depth: 2 }, [[1, 2], [3, [4, 5]], [[6]]])
+      expect(await asyncToArray(iter)).toEqual([1, 2, 3, 4, 5, 6])
+    })
+
+    it('flats using custom function', async function () {
+      const iter = asyncFlat({ shouldFlat: iter => !(typeof iter === 'string' && iter.length === 1), depth: Infinity }, [['a', 'b'], ['c', ['d', 'e']], [['fghi']]])
+      expect(await asyncToArray(iter)).toEqual(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'])
+    })
   })
 })

--- a/src/async-flat.mjs
+++ b/src/async-flat.mjs
@@ -2,7 +2,12 @@ import { asyncIterableCurry } from './internal/async-iterable'
 
 const defaultShouldFlat = item => (typeof item[Symbol.iterator] === 'function' || typeof item[Symbol.asyncIterator] === 'function') && typeof item !== 'string'
 
-function flat (shouldFlat = defaultShouldFlat, depth = 1, iterable) {
+function flat (shouldFlat = defaultShouldFlat, depthOrOptions = 1, iterable) {
+  let depth = depthOrOptions
+  if (depthOrOptions && typeof depthOrOptions === 'object') {
+    ({ shouldFlat = defaultShouldFlat, depth = 1 } = depthOrOptions)
+  }
+
   async function * _flat (currentDepth, iterable) {
     for await (const item of iterable) {
       if (currentDepth < depth && (await shouldFlat(item))) {

--- a/src/flat.mjs
+++ b/src/flat.mjs
@@ -1,28 +1,19 @@
 import { iterableCurry } from './internal/iterable'
 
-const defaultShouldIFlat = (depth) => {
-  if (typeof depth === 'function') {
-    return depth
-  }
-  if (typeof depth === 'number') {
-    return (currentDepth, iter) =>
-      currentDepth <= depth && typeof iter[Symbol.iterator] === 'function' && typeof iter !== 'string'
-  }
-  throw new Error('flat: "depth" can be a function or a number')
-}
+const defaultShouldFlat = item => typeof item[Symbol.iterator] === 'function' && typeof item !== 'string'
 
-function flat (shouldIFlat = 1, iterable) {
-  shouldIFlat = defaultShouldIFlat(shouldIFlat)
+function flat (shouldFlat = defaultShouldFlat, depth = 1, iterable) {
   function * _flat (currentDepth, iterable) {
-    if (shouldIFlat(currentDepth, iterable)) {
-      for (const iter of iterable) {
-        yield * _flat(currentDepth + 1, iter)
+    for (const item of iterable) {
+      if (currentDepth < depth && shouldFlat(item)) {
+        yield * _flat(currentDepth + 1, item)
+      } else {
+        yield item
       }
-    } else {
-      yield iterable
     }
   }
+
   return _flat(0, iterable)
 }
 
-export default iterableCurry(flat, { variadic: false, minArgs: 0, maxArgs: 1 })
+export default iterableCurry(flat, { minArgs: 0, maxArgs: 2 })

--- a/src/flat.mjs
+++ b/src/flat.mjs
@@ -2,7 +2,12 @@ import { iterableCurry } from './internal/iterable'
 
 const defaultShouldFlat = item => typeof item[Symbol.iterator] === 'function' && typeof item !== 'string'
 
-function flat (shouldFlat = defaultShouldFlat, depth = 1, iterable) {
+function flat (shouldFlat = defaultShouldFlat, depthOrOptions = 1, iterable) {
+  let depth = depthOrOptions
+  if (depthOrOptions && typeof depthOrOptions === 'object') {
+    ({ shouldFlat = defaultShouldFlat, depth = 1 } = depthOrOptions)
+  }
+
   function * _flat (currentDepth, iterable) {
     for (const item of iterable) {
       if (currentDepth < depth && shouldFlat(item)) {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -256,11 +256,14 @@ export declare function flat<
 > (depth: Depth, iter: Iter): FlatReturn<Depth, Iter>
 export declare function flat (depth: number, iter: Iterable<any>): IterableIterator<any>
 export declare function flat (
-  shouldFlat: (depth: number, iter: any) => boolean,
+  shouldFlat: (item: any) => boolean,
+  depth: number,
   iter: Iterable<any>
 ): IterableIterator<any>
-export declare function flat (shouldFlat: (depth: number, iter: any) => boolean):
-  (iter: Iterable<any>) => IterableIterator<any>
+export declare function flat (
+  shouldFlat: (item: any) => boolean,
+  depth: number
+): (iter: Iterable<any>) => IterableIterator<any>
 
 export declare function flatMap<T, O> (func: (item: T) => Iterable<O>):
   (iter: Iterable<T>) => IterableIterator<O>
@@ -582,13 +585,16 @@ export declare function asyncFlat<
   Depth extends ReasonableNumber,
   Iter extends AsyncIterableLike<any>
 > (depth: Depth, iter: Iter): AsyncFlatReturn<Depth, Iter>
-export declare function asyncFlat (depth: number, iter: AsyncIterableLike<any>): AsyncIterableIterator<any>
+export declare function asyncFlat (depth: number, item: AsyncIterableLike<any>): AsyncIterableIterator<any>
 export declare function asyncFlat (
-  shouldFlat: (depth: number, iter: any) => MaybePromise<boolean>,
+  shouldFlat: (item: any) => MaybePromise<boolean>,
+  depth: number,
   iter: AsyncIterableLike<any>
 ): AsyncIterableIterator<any>
-export declare function asyncFlat (shouldFlat: (depth: number, iter: any) => MaybePromise<boolean>):
-  (iter: AsyncIterable<any>) => AsyncIterableIterator<any>
+export declare function asyncFlat (
+  shouldFlat: (item: any) => MaybePromise<boolean>,
+  depth: number
+): (iter: AsyncIterable<any>) => AsyncIterableIterator<any>
 
 export declare function asyncFlatMap<T, O> (func: (item: T) => MaybePromise<AsyncIterableLike<O>>):
     (iter: AsyncIterableLike<T>) => AsyncIterableIterator<O>


### PR DESCRIPTION
As I am working my way through the library eliminating async duplication, and I came across our implementation of flat, which I believe has some problems:

It allows you to specify depth as a number, unless of course it doesn't. If you want to pass a custom flattening predicate, you can no longer control depth using a number, but are in essence expected to implement that part of the function's logic yourself.

It also has a particularly nasty case: `[...flat("abc")]`. The current result is `["abcde"]` but the correct result should be `["a", "b", "c"]`, which is the same as the result of simply `[..."abc"]`.